### PR TITLE
Update branch protection documentation

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -8,17 +8,6 @@
     "required_status_checks": {
       "strict": true,
       "contexts": [
-        "Quick Checks",
-        "Markdown Lint",
-        "Spell Check",
-        "Test Suite (ubuntu-latest, stable)",
-        "Test Suite (windows-latest, stable)",
-        "Test Suite (macOS-latest, stable)",
-        "Test Suite (ubuntu-latest, beta)",
-        "Documentation",
-        "MSRV (1.81.0)",
-        "Jekyll Site Build",
-        "Security Audit",
         "Required Checks"
       ]
     },


### PR DESCRIPTION
## Summary
Update branch-protection.json to reflect the actual branch protection settings that were just applied.

## Changes
- Document that only "Required Checks" is needed for branch protection
- Remove individual test suite requirements from documentation

## Why This Change?
The previous branch protection required individual test suites (like "Test Suite (macOS-latest, stable)") which caused issues with path-based CI filtering. When these jobs were skipped for docs-only changes, GitHub showed them as "Expected — Waiting for status to be reported" and it looked like the PR was stuck.

## Solution
We now only require the "Required Checks" job, which intelligently handles:
- For docs-only changes: Ensures docs checks pass
- For code changes: Ensures all tests pass
- Single source of truth for merge requirements

This fixes the confusing "Expected" status messages on PRs that only change documentation.

🤖 Generated with [Claude Code](https://claude.ai/code)