### PR TITLE
Add path filtering to security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,10 +10,42 @@ on:
     - cron: '0 2 * * *'
 
 jobs:
+  # Detect what files changed to skip security checks for docs-only changes
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    # Always run for scheduled events (daily security audit)
+    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'pull_request'
+    outputs:
+      rust: ${{ steps.changes.outputs.rust }}
+      should_run: ${{ github.event_name == 'schedule' || steps.changes.outputs.rust == 'true' }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Check for changes
+      uses: dorny/paths-filter@v3
+      id: changes
+      # Skip path filtering for scheduled runs
+      if: github.event_name != 'schedule'
+      with:
+        filters: |
+          rust:
+            - '**/*.rs'
+            - '**/Cargo.toml'
+            - '**/Cargo.lock'
+            - '.github/workflows/*.yml'
+            - '.github/workflows/*.yaml'
+            - 'deny.toml'
+            - 'rust-toolchain'
+            - 'rust-toolchain.toml'
+
   # Security audit for known vulnerabilities
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -27,6 +59,8 @@ jobs:
   deny:
     name: License Check
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -41,7 +75,8 @@ jobs:
   supply-chain:
     name: Supply Chain Security
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: changes
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.should_run == 'true'
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -59,6 +94,8 @@ jobs:
   codeql:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
## Summary
Add path-based filtering to the security workflow to skip unnecessary security scans for docs-only changes.

## Changes
- ✅ Add change detection job to identify what files changed
- ✅ Make all security jobs conditional on code changes
- ✅ Preserve daily scheduled security audits (always run)

## Security Jobs Affected
- **Security Audit** - Cargo vulnerability scanning
- **License Check** - cargo-deny license validation
- **CodeQL Analysis** - Static code analysis
- **Supply Chain Security** - SBOM generation

## When Security Checks Run
✅ **Run for:**
- Any Rust code changes (`*.rs`, `Cargo.toml`, `Cargo.lock`)
- Workflow file changes (`.github/workflows/*.yml`)
- Configuration changes (`deny.toml`, `rust-toolchain`)
- Daily scheduled audits (2 AM UTC)
- Main branch pushes (with code changes)

❌ **Skip for:**
- Documentation-only changes (`*.md`, `docs/*`)
- Non-code files (`FUNDING.yml`, `LICENSE`, etc.)
- Blog posts and website updates

## Benefits
- 🚀 **Faster CI for docs PRs** - No waiting for security scans
- 💰 **Reduced CI costs** - Less compute time on unnecessary scans
- ⚡ **Better developer experience** - Quick feedback on docs changes
- 🔒 **Maintained security** - Daily audits still run regardless

## Example Impact
PR #35 (adding FUNDING.yml) would skip:
- CodeQL Analysis (~3 minutes)
- Security Audit (~3 minutes)
- License Check (~20 seconds)

Total time saved: ~6 minutes per docs-only PR\!

🤖 Generated with [Claude Code](https://claude.ai/code)