### PR TITLE
fix: update Day 1 blog post date to May 27

### DIFF
--- a/docs/_posts/2025-05-27-day-1-building-ferrisdb-foundations.md
+++ b/docs/_posts/2025-05-27-day-1-building-ferrisdb-foundations.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Building FerrisDB - Laying the Foundations"
 subtitle: "Starting the journey: architecture design, storage engine planning, and implementing WAL + MemTable with concurrent skip lists"
-date: 2025-05-28
+date: 2025-05-27
 day: 1
 tags: [Architecture, Storage Engine, WAL, MemTable, Rust, Claude Code]
 stats: ["📊 13 tests passing", "📄 3 PRs merged", "⏱️ ~6 hours of development"]


### PR DESCRIPTION
## Summary
- Updated the Day 1 blog post date from May 28 to May 27
- Renamed the file to match Jekyll's expected naming convention

## Changes
- Changed `date: 2025-05-28` to `date: 2025-05-27` in front matter
- Renamed file from `2025-05-28-day-1-building-ferrisdb-foundations.md` to `2025-05-27-day-1-building-ferrisdb-foundations.md`

🤖 Generated with [Claude Code](https://claude.ai/code)