### PR TITLE
docs: Update PR policy to prevent direct pushes to main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,10 +105,12 @@ prettier --write "**/*.md"
 
 ### Pull Request Policy
 
+- **All changes must go through PRs** - Even maintainers should not push directly to main
 - **Maintainers**: Can merge PRs after all CI checks pass (no review required)
 - **External contributors**: Require review from a maintainer
 - All PRs must pass CI checks before merging
 - Use squash merge to keep history clean
+- **No direct pushes to main** - Use admin privileges only for emergency fixes
 
 ### Architecture Decisions
 


### PR DESCRIPTION
## Summary
Update CLAUDE.md to clarify that all changes must go through PRs, even for maintainers.

## Changes
- Add explicit rule against direct pushes to main
- Clarify when admin privileges should be used (emergency fixes only)  
- Maintain consistent development process for all contributors

## Reasoning
Even maintainers should follow the established PR process to ensure:
- ✅ Consistent CI validation
- ✅ Code review standards
- ✅ Clean git history  
- ✅ Team collaboration patterns

This prevents accidental bypassing of established checks and workflows.

🤖 Generated with [Claude Code](https://claude.ai/code)