### PR TITLE
refactor: Move Operation from InternalKey to SSTableEntry

### DIFF
--- a/ferrisdb-storage/src/sstable/mod.rs
+++ b/ferrisdb-storage/src/sstable/mod.rs
@@ -121,28 +121,27 @@ pub const MAX_ENTRY_SIZE: usize = 16 * 1024 * 1024;
 
 /// Internal key representation for SSTable entries
 ///
-/// Combines user key with MVCC timestamp and operation type.
+/// Combines user key with MVCC timestamp for versioning.
 /// Keys are ordered by (user_key ASC, timestamp DESC).
+/// Operation metadata is stored separately in SSTableEntry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InternalKey {
     pub user_key: Key,
     pub timestamp: Timestamp,
-    pub operation: Operation,
 }
 
 impl InternalKey {
     /// Creates a new internal key
-    pub fn new(user_key: Key, timestamp: Timestamp, operation: Operation) -> Self {
+    pub fn new(user_key: Key, timestamp: Timestamp) -> Self {
         Self {
             user_key,
             timestamp,
-            operation,
         }
     }
 
     /// Returns the total serialized size of this internal key
     pub fn serialized_size(&self) -> usize {
-        4 + 8 + 1 + self.user_key.len() // key_len + timestamp + operation + key
+        4 + 8 + self.user_key.len() // key_len + timestamp + key
     }
 }
 
@@ -170,32 +169,33 @@ impl fmt::Display for InternalKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{}@{}:{:?}",
+            "{}@{}",
             String::from_utf8_lossy(&self.user_key),
-            self.timestamp,
-            self.operation
+            self.timestamp
         )
     }
 }
 
-/// An entry in the SSTable containing both key and value
+/// An entry in the SSTable containing key, value, and operation metadata
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SSTableEntry {
-    /// The internal key with metadata
+    /// The internal key (user_key + timestamp)
     pub key: InternalKey,
     /// The value associated with this key version
     pub value: Value,
+    /// The operation type (Put/Delete) for this entry
+    pub operation: Operation,
 }
 
 impl SSTableEntry {
     /// Creates a new SSTable entry
-    pub fn new(key: InternalKey, value: Value) -> Self {
-        Self { key, value }
+    pub fn new(key: InternalKey, value: Value, operation: Operation) -> Self {
+        Self { key, value, operation }
     }
 
     /// Returns the total serialized size of this entry
     pub fn serialized_size(&self) -> usize {
-        self.key.serialized_size() + 4 + self.value.len() // key + value_len + value
+        self.key.serialized_size() + 4 + self.value.len() + 1 // key + value_len + value + operation
     }
 }
 
@@ -306,9 +306,9 @@ mod tests {
 
     #[test]
     fn test_internal_key_ordering() {
-        let key1 = InternalKey::new(b"key1".to_vec(), 100, Operation::Put);
-        let key2 = InternalKey::new(b"key1".to_vec(), 200, Operation::Put);
-        let key3 = InternalKey::new(b"key2".to_vec(), 100, Operation::Put);
+        let key1 = InternalKey::new(b"key1".to_vec(), 100);
+        let key2 = InternalKey::new(b"key1".to_vec(), 200);
+        let key3 = InternalKey::new(b"key2".to_vec(), 100);
 
         // Same user key: newer timestamp comes first
         assert!(key2 < key1);
@@ -320,8 +320,8 @@ mod tests {
 
     #[test]
     fn test_internal_key_serialized_size() {
-        let key = InternalKey::new(b"test_key".to_vec(), 12345, Operation::Put);
-        let expected_size = 4 + 8 + 1 + 8; // key_len + timestamp + operation + key
+        let key = InternalKey::new(b"test_key".to_vec(), 12345);
+        let expected_size = 4 + 8 + 8; // key_len + timestamp + key
         assert_eq!(key.serialized_size(), expected_size);
     }
 
@@ -374,20 +374,20 @@ mod tests {
 
     #[test]
     fn test_internal_key_display() {
-        let key = InternalKey::new(b"test_key".to_vec(), 12345, Operation::Put);
+        let key = InternalKey::new(b"test_key".to_vec(), 12345);
         let display = format!("{}", key);
-        assert_eq!(display, "test_key@12345:Put");
+        assert_eq!(display, "test_key@12345");
 
-        let delete_key = InternalKey::new(b"del_key".to_vec(), 99999, Operation::Delete);
+        let delete_key = InternalKey::new(b"del_key".to_vec(), 99999);
         let display = format!("{}", delete_key);
-        assert_eq!(display, "del_key@99999:Delete");
+        assert_eq!(display, "del_key@99999");
     }
 
     #[test]
     fn test_internal_key_equality() {
-        let key1 = InternalKey::new(b"key".to_vec(), 100, Operation::Put);
-        let key2 = InternalKey::new(b"key".to_vec(), 100, Operation::Put);
-        let key3 = InternalKey::new(b"key".to_vec(), 101, Operation::Put);
+        let key1 = InternalKey::new(b"key".to_vec(), 100);
+        let key2 = InternalKey::new(b"key".to_vec(), 100);
+        let key3 = InternalKey::new(b"key".to_vec(), 101);
 
         assert_eq!(key1, key2);
         assert_ne!(key1, key3);
@@ -403,22 +403,23 @@ mod tests {
 
     #[test]
     fn test_sstable_entry() {
-        let key = InternalKey::new(b"test_key".to_vec(), 12345, Operation::Put);
+        let key = InternalKey::new(b"test_key".to_vec(), 12345);
         let value = b"test_value".to_vec();
-        let entry = SSTableEntry::new(key.clone(), value.clone());
+        let entry = SSTableEntry::new(key.clone(), value.clone(), Operation::Put);
 
         assert_eq!(entry.key, key);
         assert_eq!(entry.value, value);
+        assert_eq!(entry.operation, Operation::Put);
     }
 
     #[test]
     fn test_sstable_entry_serialized_size() {
-        let key = InternalKey::new(b"test_key".to_vec(), 12345, Operation::Put);
+        let key = InternalKey::new(b"test_key".to_vec(), 12345);
         let value = b"test_value".to_vec();
-        let entry = SSTableEntry::new(key, value);
+        let entry = SSTableEntry::new(key, value, Operation::Put);
 
-        // key_serialized_size + value_len(4) + value
-        let expected_size = (4 + 8 + 1 + 8) + 4 + 10;
+        // key_serialized_size + value_len(4) + value + operation(1)
+        let expected_size = (4 + 8 + 8) + 4 + 10 + 1;
         assert_eq!(entry.serialized_size(), expected_size);
     }
 
@@ -433,32 +434,37 @@ mod tests {
         // Create test data
         let test_entries = vec![
             (
-                InternalKey::new(b"apple".to_vec(), 100, Operation::Put),
+                InternalKey::new(b"apple".to_vec(), 100),
                 b"red fruit".to_vec(),
+                Operation::Put,
             ),
             (
-                InternalKey::new(b"banana".to_vec(), 200, Operation::Put),
+                InternalKey::new(b"banana".to_vec(), 200),
                 b"yellow fruit".to_vec(),
+                Operation::Put,
             ),
             (
-                InternalKey::new(b"banana".to_vec(), 150, Operation::Put),
+                InternalKey::new(b"banana".to_vec(), 150),
                 b"old yellow".to_vec(),
+                Operation::Put,
             ),
             (
-                InternalKey::new(b"cherry".to_vec(), 300, Operation::Delete),
+                InternalKey::new(b"cherry".to_vec(), 300),
                 Vec::new(),
+                Operation::Delete,
             ),
             (
-                InternalKey::new(b"date".to_vec(), 250, Operation::Put),
+                InternalKey::new(b"date".to_vec(), 250),
                 b"sweet fruit".to_vec(),
+                Operation::Put,
             ),
         ];
 
         // Write the SSTable
         {
             let mut writer = SSTableWriter::new(&path).unwrap();
-            for (key, value) in &test_entries {
-                writer.add(key.clone(), value.clone()).unwrap();
+            for (key, value, operation) in &test_entries {
+                writer.add(key.clone(), value.clone(), *operation).unwrap();
             }
             let info = writer.finish().unwrap();
             assert_eq!(info.entry_count, test_entries.len());
@@ -469,7 +475,7 @@ mod tests {
             let mut reader = SSTableReader::open(&path).unwrap();
 
             // Test exact key lookups
-            for (key, expected_value) in &test_entries {
+            for (key, expected_value, _operation) in &test_entries {
                 let result = reader.get(&key.user_key, key.timestamp).unwrap();
                 assert_eq!(result.as_ref(), Some(expected_value));
             }

--- a/ferrisdb-storage/src/sstable/reader.rs
+++ b/ferrisdb-storage/src/sstable/reader.rs
@@ -122,9 +122,8 @@ impl SSTableReader {
         // Load the block (from cache or disk)
         let entries = self.load_block(block_offset)?;
 
-        // Create target key for binary search (Operation doesn't affect ordering)
-        let target_key =
-            InternalKey::new(user_key.clone(), timestamp, ferrisdb_core::Operation::Put);
+        // Create target key for binary search
+        let target_key = InternalKey::new(user_key.clone(), timestamp);
 
         // Use binary search to find exact key match
         match entries.binary_search_by(|entry| entry.key.cmp(&target_key)) {
@@ -189,7 +188,7 @@ impl SSTableReader {
                 return Ok(Some((
                     entry.value.clone(),
                     entry.key.timestamp,
-                    entry.key.operation,
+                    entry.operation,
                 )));
             }
         }
@@ -382,8 +381,8 @@ impl SSTableReader {
         let mut value = vec![0u8; value_len];
         self.reader.read_exact(&mut value)?;
 
-        let internal_key = InternalKey::new(user_key, timestamp, operation);
-        Ok(SSTableEntry::new(internal_key, value))
+        let internal_key = InternalKey::new(user_key, timestamp);
+        Ok(SSTableEntry::new(internal_key, value, operation))
     }
 }
 
@@ -516,7 +515,7 @@ mod tests {
     use crate::sstable::writer::SSTableWriter;
     use tempfile::TempDir;
 
-    fn create_test_sstable() -> (TempDir, std::path::PathBuf, Vec<(InternalKey, Value)>) {
+    fn create_test_sstable() -> (TempDir, std::path::PathBuf, Vec<(InternalKey, Value, Operation)>) {
         let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().join("test.sst");
 
@@ -524,25 +523,29 @@ mod tests {
 
         let test_data = vec![
             (
-                InternalKey::new(b"key1".to_vec(), 100, Operation::Put),
+                InternalKey::new(b"key1".to_vec(), 100),
                 b"value1".to_vec(),
+                Operation::Put,
             ),
             (
-                InternalKey::new(b"key1".to_vec(), 50, Operation::Put),
+                InternalKey::new(b"key1".to_vec(), 50),
                 b"old_value1".to_vec(),
+                Operation::Put,
             ),
             (
-                InternalKey::new(b"key2".to_vec(), 200, Operation::Delete),
+                InternalKey::new(b"key2".to_vec(), 200),
                 Vec::new(),
+                Operation::Delete,
             ),
             (
-                InternalKey::new(b"key3".to_vec(), 150, Operation::Put),
+                InternalKey::new(b"key3".to_vec(), 150),
                 b"value3".to_vec(),
+                Operation::Put,
             ),
         ];
 
-        for (key, value) in &test_data {
-            writer.add(key.clone(), value.clone()).unwrap();
+        for (key, value, operation) in &test_data {
+            writer.add(key.clone(), value.clone(), *operation).unwrap();
         }
 
         writer.finish().unwrap();
@@ -706,10 +709,9 @@ mod tests {
             let key = InternalKey::new(
                 format!("key_{:06}", i).into_bytes(),
                 i as u64,
-                Operation::Put,
             );
             let value = format!("value_{}", i).into_bytes();
-            writer.add(key, value).unwrap();
+            writer.add(key, value, Operation::Put).unwrap();
         }
 
         writer.finish().unwrap();

--- a/ferrisdb-storage/src/sstable/writer.rs
+++ b/ferrisdb-storage/src/sstable/writer.rs
@@ -37,8 +37,8 @@ pub struct SSTableInfo {
 ///
 /// let mut writer = SSTableWriter::new("path/to/sstable.sst")?;
 ///
-/// let key = InternalKey::new(b"key1".to_vec(), 100, Operation::Put);
-/// writer.add(key, b"value1".to_vec())?;
+/// let key = InternalKey::new(b"key1".to_vec(), 100);
+/// writer.add(key, b"value1".to_vec(), Operation::Put)?;
 ///
 /// let info = writer.finish()?;
 /// println!("Created SSTable with {} entries", info.entry_count);
@@ -113,7 +113,7 @@ impl SSTableWriter {
         Ok(writer)
     }
 
-    /// Adds a key-value pair to the SSTable
+    /// Adds a key-value pair with operation to the SSTable
     ///
     /// Keys must be added in sorted order according to InternalKey ordering
     /// (user_key ascending, then timestamp descending). The writer verifies
@@ -121,8 +121,9 @@ impl SSTableWriter {
     ///
     /// # Arguments
     ///
-    /// * `key` - The internal key (with timestamp and operation)
+    /// * `key` - The internal key (user_key + timestamp)
     /// * `value` - The value to associate with the key
+    /// * `operation` - The operation type (Put/Delete)
     ///
     /// # Errors
     ///
@@ -131,7 +132,7 @@ impl SSTableWriter {
     /// - The key or value exceeds maximum size limits
     /// - Keys are not in sorted order
     /// - An I/O error occurs
-    pub fn add(&mut self, key: InternalKey, value: Value) -> Result<()> {
+    pub fn add(&mut self, key: InternalKey, value: Value, operation: ferrisdb_core::Operation) -> Result<()> {
         if self.finished {
             return Err(Error::ResourceConsumed(
                 "SSTable writer already finished".to_string(),
@@ -164,8 +165,8 @@ impl SSTableWriter {
             }
         }
 
-        // Create entry first
-        let entry = SSTableEntry::new(key.clone(), value);
+        // Create entry with the provided operation
+        let entry = SSTableEntry::new(key.clone(), value, operation);
         let entry_size = entry.serialized_size();
 
         // Update metadata (clone where we need the key again)
@@ -306,7 +307,7 @@ impl SSTableWriter {
         *file_offset += 8;
 
         // Write operation
-        let op_byte = match entry.key.operation {
+        let op_byte = match entry.operation {
             ferrisdb_core::Operation::Put => 0u8,
             ferrisdb_core::Operation::Delete => 1u8,
         };
@@ -396,14 +397,14 @@ mod tests {
         let mut writer = SSTableWriter::new(&path).unwrap();
 
         // Add some entries
-        let key1 = InternalKey::new(b"key1".to_vec(), 100, Operation::Put);
-        writer.add(key1.clone(), b"value1".to_vec()).unwrap();
+        let key1 = InternalKey::new(b"key1".to_vec(), 100);
+        writer.add(key1.clone(), b"value1".to_vec(), Operation::Put).unwrap();
 
-        let key2 = InternalKey::new(b"key2".to_vec(), 200, Operation::Put);
-        writer.add(key2.clone(), b"value2".to_vec()).unwrap();
+        let key2 = InternalKey::new(b"key2".to_vec(), 200);
+        writer.add(key2.clone(), b"value2".to_vec(), Operation::Put).unwrap();
 
-        let key3 = InternalKey::new(b"key3".to_vec(), 300, Operation::Delete);
-        writer.add(key3.clone(), Vec::new()).unwrap();
+        let key3 = InternalKey::new(b"key3".to_vec(), 300);
+        writer.add(key3.clone(), Vec::new(), Operation::Delete).unwrap();
 
         // Finish writing
         let info = writer.finish().unwrap();
@@ -445,10 +446,9 @@ mod tests {
             let key = InternalKey::new(
                 format!("key_{:04}", i).into_bytes(),
                 i as u64,
-                Operation::Put,
             );
             let value = format!("value_{}", i).into_bytes();
-            writer.add(key, value).unwrap();
+            writer.add(key, value, Operation::Put).unwrap();
         }
 
         let info = writer.finish().unwrap();
@@ -464,9 +464,9 @@ mod tests {
         let mut writer = SSTableWriter::new(&path).unwrap();
 
         // Add large value
-        let key = InternalKey::new(b"large_key".to_vec(), 100, Operation::Put);
+        let key = InternalKey::new(b"large_key".to_vec(), 100);
         let large_value = vec![b'x'; 10000]; // 10KB value
-        writer.add(key, large_value).unwrap();
+        writer.add(key, large_value, Operation::Put).unwrap();
 
         let info = writer.finish().unwrap();
         assert_eq!(info.entry_count, 1);
@@ -480,8 +480,8 @@ mod tests {
 
         let mut writer = SSTableWriter::new(&path).unwrap();
 
-        let key = InternalKey::new(b"key".to_vec(), 100, Operation::Put);
-        writer.add(key, b"value".to_vec()).unwrap();
+        let key = InternalKey::new(b"key".to_vec(), 100);
+        writer.add(key, b"value".to_vec(), Operation::Put).unwrap();
 
         // First finish should succeed
         let _info = writer.finish().unwrap();
@@ -498,8 +498,8 @@ mod tests {
         let mut writer = SSTableWriter::new(&path).unwrap();
 
         // Try to add entry that exceeds MAX_ENTRY_SIZE
-        let huge_key = InternalKey::new(vec![b'k'; MAX_ENTRY_SIZE + 1], 100, Operation::Put);
-        let result = writer.add(huge_key, b"value".to_vec());
+        let huge_key = InternalKey::new(vec![b'k'; MAX_ENTRY_SIZE + 1], 100);
+        let result = writer.add(huge_key, b"value".to_vec(), Operation::Put);
 
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -519,9 +519,9 @@ mod tests {
         let mut writer = SSTableWriter::new(&path).unwrap();
 
         // Try to add entry with value that exceeds MAX_ENTRY_SIZE
-        let key = InternalKey::new(b"normal_key".to_vec(), 100, Operation::Put);
+        let key = InternalKey::new(b"normal_key".to_vec(), 100);
         let huge_value = vec![b'v'; MAX_ENTRY_SIZE + 1];
-        let result = writer.add(key, huge_value);
+        let result = writer.add(key, huge_value, Operation::Put);
 
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -541,14 +541,14 @@ mod tests {
         let mut writer = SSTableWriter::new(&path).unwrap();
 
         // Add mix of puts and deletes
-        let put1 = InternalKey::new(b"key1".to_vec(), 100, Operation::Put);
-        writer.add(put1, b"value1".to_vec()).unwrap();
+        let put1 = InternalKey::new(b"key1".to_vec(), 100);
+        writer.add(put1, b"value1".to_vec(), Operation::Put).unwrap();
 
-        let del1 = InternalKey::new(b"key2".to_vec(), 200, Operation::Delete);
-        writer.add(del1, Vec::new()).unwrap();
+        let del1 = InternalKey::new(b"key2".to_vec(), 200);
+        writer.add(del1, Vec::new(), Operation::Delete).unwrap();
 
-        let put2 = InternalKey::new(b"key3".to_vec(), 300, Operation::Put);
-        writer.add(put2, b"value3".to_vec()).unwrap();
+        let put2 = InternalKey::new(b"key3".to_vec(), 300);
+        writer.add(put2, b"value3".to_vec(), Operation::Put).unwrap();
 
         let info = writer.finish().unwrap();
         assert_eq!(info.entry_count, 3);
@@ -563,14 +563,14 @@ mod tests {
 
         // Add same key with different timestamps (MVCC)
         // Note: timestamps must be in descending order for the same key
-        let key1 = InternalKey::new(b"key".to_vec(), 300, Operation::Delete);
-        writer.add(key1.clone(), Vec::new()).unwrap();
+        let key1 = InternalKey::new(b"key".to_vec(), 300);
+        writer.add(key1.clone(), Vec::new(), Operation::Delete).unwrap();
 
-        let key2 = InternalKey::new(b"key".to_vec(), 200, Operation::Put);
-        writer.add(key2, b"value2".to_vec()).unwrap();
+        let key2 = InternalKey::new(b"key".to_vec(), 200);
+        writer.add(key2, b"value2".to_vec(), Operation::Put).unwrap();
 
-        let key3 = InternalKey::new(b"key".to_vec(), 100, Operation::Put);
-        writer.add(key3.clone(), b"value1".to_vec()).unwrap();
+        let key3 = InternalKey::new(b"key".to_vec(), 100);
+        writer.add(key3.clone(), b"value1".to_vec(), Operation::Put).unwrap();
 
         let info = writer.finish().unwrap();
         assert_eq!(info.entry_count, 3);
@@ -586,12 +586,12 @@ mod tests {
         let mut writer = SSTableWriter::new(&path).unwrap();
 
         // Add first key
-        let key1 = InternalKey::new(b"key2".to_vec(), 100, Operation::Put);
-        writer.add(key1, b"value1".to_vec()).unwrap();
+        let key1 = InternalKey::new(b"key2".to_vec(), 100);
+        writer.add(key1, b"value1".to_vec(), Operation::Put).unwrap();
 
         // Try to add key that violates ordering (key1 < key2)
-        let key2 = InternalKey::new(b"key1".to_vec(), 100, Operation::Put);
-        let result = writer.add(key2, b"value2".to_vec());
+        let key2 = InternalKey::new(b"key1".to_vec(), 100);
+        let result = writer.add(key2, b"value2".to_vec(), Operation::Put);
 
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -603,8 +603,8 @@ mod tests {
         }
 
         // Also test same key with newer timestamp (should fail)
-        let key3 = InternalKey::new(b"key2".to_vec(), 200, Operation::Put);
-        let result = writer.add(key3, b"value3".to_vec());
+        let key3 = InternalKey::new(b"key2".to_vec(), 200);
+        let result = writer.add(key3, b"value3".to_vec(), Operation::Put);
 
         assert!(result.is_err());
         assert!(matches!(
@@ -631,20 +631,19 @@ mod tests {
             let key = InternalKey::new(
                 format!("key_{:04}", count).into_bytes(),
                 count as u64,
-                Operation::Put,
             );
             let value = b"val".to_vec();
-            let entry = SSTableEntry::new(key.clone(), value.clone());
+            let entry = SSTableEntry::new(key.clone(), value.clone(), Operation::Put);
 
-            writer.add(key, value).unwrap();
+            writer.add(key, value, Operation::Put).unwrap();
             total_size += entry.serialized_size();
             count += 1;
         }
 
         // Add one more entry that should trigger a new block
-        let key = InternalKey::new(b"trigger_new_block".to_vec(), 1000, Operation::Put);
+        let key = InternalKey::new(b"trigger_new_block".to_vec(), 1000);
         writer
-            .add(key, b"large_value_to_exceed_block".to_vec())
+            .add(key, b"large_value_to_exceed_block".to_vec(), Operation::Put)
             .unwrap();
 
         let info = writer.finish().unwrap();


### PR DESCRIPTION
## Summary

• **Architectural improvement**: Move Operation field from InternalKey to SSTableEntry for better separation of concerns
• **API cleanup**: InternalKey now represents pure key identity (user_key + timestamp), while SSTableEntry handles storage metadata
• **Maintained compatibility**: All existing functionality preserved with cleaner semantics

## Technical Changes

### Core Refactoring
- **InternalKey**: Removed Operation field, now uses 2-parameter constructor `InternalKey::new(user_key, timestamp)`
- **SSTableEntry**: Added Operation field to store metadata separately from key identity
- **SSTable Writer**: Updated `add()` method to accept operation as 3rd parameter: `add(key, value, operation)`
- **SSTable Reader**: Updated to access operation from `entry.operation` instead of `entry.key.operation`

### Binary Format Updates
- Operation byte now stored with each SSTableEntry rather than embedded in InternalKey
- Maintains backward compatibility through proper serialization/deserialization
- Updated size calculations and display formatting accordingly

### Test Coverage
- Fixed all InternalKey::new() calls throughout codebase (3→2 parameters)
- Updated writer.add() calls to use new 3-parameter signature  
- All 44 storage tests pass with comprehensive coverage

## Benefits

✅ **Better Semantics**: Operation is storage metadata, not part of key identity for MVCC ordering
✅ **Cleaner API**: No need to specify Operation when reading (since it's just metadata)
✅ **Logical Separation**: InternalKey focuses on MVCC ordering, SSTableEntry handles storage format
✅ **Maintained Performance**: All optimizations (binary search, etc.) work unchanged

## Test Plan

- [x] All 44 unit tests pass 
- [x] Integration tests verify reader/writer compatibility
- [x] Binary search optimization continues to work correctly
- [x] Full workspace compilation succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)