### PR TITLE
docs: Add blog post statistics gathering guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,31 @@ stats: ["📊 X tests passing", "📄 Y PRs merged", "⏱️ Key achievement"]
 ---
 ```
 
+**Gathering Statistics for Blog Posts:**
+
+Before writing a daily blog post, gather accurate statistics:
+
+```bash
+# Count total tests across all crates
+cargo test --all --quiet 2>&1 | grep -E "test result:" | grep -oE "[0-9]+ passed" | awk '{sum += $1} END {print "Total tests: " sum}'
+
+# List technical PRs merged on the day (adjust dates)
+gh pr list --state merged --limit 50 --json number,title,mergedAt | jq -r '.[] | select(.mergedAt >= "2025-05-28T00:00:00Z" and .mergedAt < "2025-05-29T00:00:00Z") | "\(.number) - \(.title)"' | grep -E "(feat:|fix:|refactor:|perf:|test:)"
+
+# Check current branch for recent commits
+git log --oneline --since="1 day ago" --until="now"
+
+# Verify feature completeness
+grep -E "\[x\].*\(Day [0-9]+\)" TODO.md
+```
+
+**Stats Line Format:**
+
+- First stat: Always include test count (e.g., "📊 55 tests passing")
+- Second stat: Number of technical PRs merged (exclude docs-only PRs)
+- Remaining stats: Key technical achievements of the day
+- Be specific with numbers and achievements, not generic
+
 **When to Write Blog Posts:**
 
 - End of each development day (summarizing progress)


### PR DESCRIPTION
## Summary
This PR adds specific guidelines to CLAUDE.md for gathering accurate statistics when writing daily blog posts.

## Changes Made
- Added bash commands to count total tests across all crates
- Added commands to filter and count technical PRs (excluding docs-only changes)
- Added commands to check recent commits and feature completeness
- Specified the required format for stats lines in blog posts
- Emphasized using specific numbers rather than generic claims

## Why This Matters
As we discovered when reviewing the Day 2 blog post, accurate statistics are important for:
1. Tracking actual progress
2. Providing verifiable claims about achievements
3. Maintaining credibility in technical blog posts

## Example Usage
```bash
# Count tests (Day 2 showed 55, not 44)
cargo test --all --quiet 2>&1  < /dev/null |  grep -E "test result:" | grep -oE "[0-9]+ passed" | awk '{sum += $1} END {print "Total tests: " sum}'

# Count technical PRs for a specific day
gh pr list --state merged --limit 50 --json number,title,mergedAt | jq -r '.[] | select(.mergedAt >= "2025-05-28T00:00:00Z" and .mergedAt < "2025-05-29T00:00:00Z") | "\(.number) - \(.title)"' | grep -E "(feat:|fix:|refactor:|perf:|test:)"
```

## Testing
- All markdown passes linting
- Commands have been tested and work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)