### PR TITLE
docs: Add honesty guidelines for benchmarks and documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,14 @@ FerrisDB is a distributed, transactional key-value database inspired by Foundati
 - Generate docs with `cargo doc --all --no-deps --open`
 - Review generated documentation before submitting PRs
 
+**Documentation Honesty:**
+
+- **Be transparent about implementation status** - Clearly indicate what's implemented vs planned
+- **Don't claim features that don't exist** - Use "will" or "planned" for future features
+- **Acknowledge limitations** - Be upfront about what the system can't do yet
+- **Mark hypothetical examples** - Label code examples that show expected behavior vs actual
+- **Update docs when features land** - Keep documentation in sync with actual capabilities
+
 **Markdown Quality (REQUIRED before commit):**
 
 1. **Format first**: `prettier --write "**/*.md"`
@@ -335,6 +343,14 @@ None / List any breaking changes here
 - Prefer zero-copy operations where possible
 - Use `bytes` crate for efficient buffer management
 - Implement proper batching for I/O operations
+
+**Benchmark Honesty:**
+
+- **Never claim benchmark results without running them** - Be transparent about theoretical vs actual performance
+- **Clearly label expected performance** - Use phrases like "expected", "theoretical", or "should achieve"
+- **Document benchmark methodology** - When you do run benchmarks, document the setup and conditions
+- **Avoid misleading claims** - Don't present example numbers as if they were measured results
+- **Update when benchmarks are run** - Replace theoretical numbers with actual measurements once available
 
 ### Memory Safety
 


### PR DESCRIPTION
## Summary

This PR adds important guidelines to CLAUDE.md about being honest and transparent in our documentation and benchmark claims.

## Changes Made

- Added "Benchmark Honesty" section under Performance Guidelines
- Added "Documentation Honesty" section under Documentation
- Emphasized transparency about theoretical vs actual performance
- Required clear labeling when discussing expected behavior vs implemented features

## Why This Matters

During our deep dive article review, we noticed that some benchmark results were presented as if they were actual measurements when they were theoretical expectations. This could mislead readers and damage trust. These guidelines ensure we:

1. Never claim benchmark results without actually running them
2. Clearly distinguish between what's implemented and what's planned
3. Are upfront about limitations and current capabilities
4. Maintain trust through transparency

## Testing

N/A - Documentation only change

## Breaking Changes

None