### PR TITLE
docs: Add deep dive article writing guidelines for accessibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,14 @@ FerrisDB is a distributed, transactional key-value database inspired by Foundati
 - Generate docs with `cargo doc --all --no-deps --open`
 - Review generated documentation before submitting PRs
 
+**Documentation Honesty:**
+
+- **Be transparent about implementation status** - Clearly indicate what's implemented vs planned
+- **Don't claim features that don't exist** - Use "will" or "planned" for future features
+- **Acknowledge limitations** - Be upfront about what the system can't do yet
+- **Mark hypothetical examples** - Label code examples that show expected behavior vs actual
+- **Update docs when features land** - Keep documentation in sync with actual capabilities
+
 **Markdown Quality (REQUIRED before commit):**
 
 1. **Format first**: `prettier --write "**/*.md"`
@@ -335,6 +343,14 @@ None / List any breaking changes here
 - Prefer zero-copy operations where possible
 - Use `bytes` crate for efficient buffer management
 - Implement proper batching for I/O operations
+
+**Benchmark Honesty:**
+
+- **Never claim benchmark results without running them** - Be transparent about theoretical vs actual performance
+- **Clearly label expected performance** - Use phrases like "expected", "theoretical", or "should achieve"
+- **Document benchmark methodology** - When you do run benchmarks, document the setup and conditions
+- **Avoid misleading claims** - Don't present example numbers as if they were measured results
+- **Update when benchmarks are run** - Replace theoretical numbers with actual measurements once available
 
 ### Memory Safety
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,36 @@ Common issues prettier might miss:
 - Tag posts with relevant categories for easy discovery
 - Write posts after major features, interesting debugging sessions, or collaboration insights
 
+### Deep Dive Articles
+
+**Writing for Developers, Not Academics:**
+
+- **Target audience**: Typical developers, not PhD students or researchers
+- **Explain jargon**: Always define technical terms when first used (e.g., "ABA problem" needs explanation)
+- **Use analogies**: Complex concepts benefit from real-world comparisons
+- **Show don't tell**: Use concrete examples instead of abstract descriptions
+- **Progressive complexity**: Start simple, build up to advanced concepts
+- **Avoid assumptions**: Don't assume readers know advanced CS topics
+- **Conversational tone**: Write like you're explaining to a colleague, not lecturing
+
+**Deep Dive Structure:**
+
+1. **Hook**: Start with a relatable problem or question
+2. **Context**: Why should developers care about this topic?
+3. **Fundamentals**: Explain basic concepts before diving deep
+4. **Implementation**: Show real code with clear explanations
+5. **Trade-offs**: Discuss pros, cons, and when to use
+6. **Practical tips**: Give actionable advice
+7. **Resources**: Link to further reading for those who want more
+
+**Examples of Good Explanations:**
+
+- ❌ "Uses epoch-based reclamation to avoid ABA problems"
+- ✅ "Uses epoch-based reclamation to avoid the ABA problem - a concurrency issue where a memory location is changed from A to B and back to A, making it appear unchanged when it actually was modified"
+
+- ❌ "O(log n) complexity"
+- ✅ "O(log n) complexity - meaning if you have 1,000 items, you only need ~10 comparisons instead of 1,000"
+
 **Blog Post Format (for main blog):**
 
 ```yaml

--- a/docs/deep-dive/index.md
+++ b/docs/deep-dive/index.md
@@ -7,6 +7,14 @@ permalink: /deep-dive/
 
 Welcome to FerrisDB's technical deep dives! These articles explore fundamental database concepts through our actual implementation, providing both theoretical understanding and practical code examples.
 
+**Who are these articles for?**
+
+- Developers curious about how databases work internally
+- Engineers building data-intensive applications
+- Anyone who's wondered "but how does it actually work?"
+
+No PhD required! We explain complex concepts in plain English with real-world analogies.
+
 ## Storage Engine Fundamentals
 
 <div class="article-grid">
@@ -70,13 +78,13 @@ Welcome to FerrisDB's technical deep dives! These articles explore fundamental d
 
 Each deep dive article:
 
-- **Explains the problem** the technology solves
-- **Shows real code** from FerrisDB's implementation
-- **Compares approaches** used by other databases
-- **Includes performance analysis** where applicable
-- **Provides hands-on examples** you can run
+- **Explains the problem** the technology solves (why should you care?)
+- **Shows real code** from FerrisDB's implementation (not pseudocode!)
+- **Compares approaches** used by other databases (learn from the giants)
+- **Includes performance analysis** where applicable (with actual numbers)
+- **Provides hands-on examples** you can run (try it yourself!)
 
-These aren't just theoretical explanations - they're based on actual code we've written and lessons we've learned building FerrisDB.
+These aren't just theoretical explanations - they're based on actual code we've written and lessons we've learned building FerrisDB. We share our mistakes and "aha!" moments so you can learn alongside us.
 
 ## Contributing
 

--- a/docs/deep-dive/wal-crash-recovery.md
+++ b/docs/deep-dive/wal-crash-recovery.md
@@ -169,6 +169,11 @@ pub fn read_entry(&mut self) -> Result<Option<WALEntry>> {
         return Ok(None);
     }
 
+    // Why skip instead of panic?
+    // - Partial write during crash (normal)
+    // - Disk corruption (unfortunate but happens)
+    // - Better to lose one entry than crash on startup
+
     // Decode valid entry
     let entry = WALEntry::decode(&entry_buf[4..])?;
     Ok(Some(entry))


### PR DESCRIPTION
## Summary

This PR adds comprehensive guidelines to CLAUDE.md for writing accessible deep dive articles that can be understood by typical developers, not just academics.

## Changes Made

- Added "Deep Dive Articles" section with detailed writing guidelines
- Emphasized writing for typical developers, not PhD students
- Required explanations for all technical jargon
- Encouraged use of analogies and real-world examples
- Added examples of good vs bad explanations
- Specified a clear structure for deep dive articles

## Why This Matters

During our review of the deep dive articles, we realized that while our current articles are already quite accessible, we should document these best practices to ensure future articles maintain the same approachable style.

For example, concepts like 'ABA problems' or 'O(log n) complexity' need clear explanations for developers who may not have a computer science background.

## Testing

N/A - Documentation only change

## Breaking Changes

None

## Note

This builds on PR #54 which added honesty guidelines. This PR focuses specifically on making technical content accessible to all developers.