### PR TITLE
docs: Improve skip list diagram formatting for better readability

### DIFF
--- a/docs/deep-dive/concurrent-skip-list.md
+++ b/docs/deep-dive/concurrent-skip-list.md
@@ -44,10 +44,10 @@ Skip lists are probabilistic data structures that provide O(log n) operations li
 ### Skip List Structure
 
 ```text
-Level 3: HEAD -----------------> 30 -----------------------> NULL
-Level 2: HEAD ------> 10 ------> 30 --------> 50 ----------> NULL
-Level 1: HEAD -> 5 -> 10 -> 20-> 30 -> 40 -> 50 -> 60 -----> NULL
-Level 0: HEAD -> 5 -> 10 -> 20-> 30 -> 40 -> 50 -> 60 -> 70  NULL
+Level 3: HEAD ------------------> 30 -------------------------> NULL
+Level 2: HEAD ------> 10 -------> 30 -------> 50 -------------> NULL
+Level 1: HEAD -> 5 -> 10 -> 20 -> 30 -> 40 -> 50 -> 60 -------> NULL
+Level 0: HEAD -> 5 -> 10 -> 20 -> 30 -> 40 -> 50 -> 60 -> 70 -> NULL
 ```
 
 Each node has a random height, creating "express lanes" for faster traversal.


### PR DESCRIPTION
## Summary

This PR improves the formatting of the skip list diagram in the concurrent skip list deep dive article for better visual clarity.

## Changes Made

- Fixed inconsistent spacing between arrows in the ASCII diagram
- Aligned nodes more consistently across all levels
- Added missing space before NULL on Level 0
- Made the diagram easier to follow by ensuring consistent formatting

## Why This Matters

The skip list diagram is a key visual aid for understanding how skip lists work. The improved formatting makes it easier to see the "express lanes" concept and understand how nodes are connected across different levels.

## Before

```text
Level 3: HEAD -----------------> 30 -----------------------> NULL
Level 2: HEAD ------> 10 ------> 30 --------> 50 ----------> NULL
Level 1: HEAD -> 5 -> 10 -> 20-> 30 -> 40 -> 50 -> 60 -----> NULL
Level 0: HEAD -> 5 -> 10 -> 20-> 30 -> 40 -> 50 -> 60 -> 70  NULL
```

## After

```text
Level 3: HEAD ------------------> 30 -------------------------> NULL
Level 2: HEAD ------> 10 -------> 30 -------> 50 -------------> NULL
Level 1: HEAD -> 5 -> 10 -> 20 -> 30 -> 40 -> 50 -> 60 -------> NULL
Level 0: HEAD -> 5 -> 10 -> 20 -> 30 -> 40 -> 50 -> 60 -> 70 -> NULL
```

## Testing

- Verified the diagram renders correctly in markdown preview
- Ensured all nodes and connections are properly aligned

## Breaking Changes

None - This is a documentation-only change.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>