### PR TITLE
fix: Remove duplicate hero sections and improve hero design

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -188,7 +188,7 @@ body {
     // Content wrapper
     .hero-content {
         position: relative;
-        max-width: 1000px;
+        max-width: 1200px;
         margin: 0 auto;
     }
     
@@ -205,30 +205,36 @@ body {
     }
     
     .hero-title {
-        font-size: clamp(2.5rem, 5vw, 4rem);
+        font-size: clamp(2.25rem, 4vw, 3.25rem);
         font-weight: 700;
         margin-bottom: 1.5rem;
         line-height: 1.2;
         letter-spacing: -0.02em;
+        max-width: 1100px;
+        margin-left: auto;
+        margin-right: auto;
     }
     
     .hero-subtitle {
-        font-size: clamp(1.125rem, 2vw, 1.5rem);
+        font-size: clamp(1.125rem, 1.75vw, 1.375rem);
         margin-bottom: 3rem;
         opacity: 0.95;
-        max-width: 800px;
+        max-width: 900px;
         margin-left: auto;
         margin-right: auto;
-        line-height: 1.6;
+        line-height: 1.7;
         font-weight: 400;
     }
     
     .hero-stats {
         display: flex;
         justify-content: center;
-        gap: 1.5rem;
+        gap: 2rem;
         margin-bottom: 3rem;
         flex-wrap: wrap;
+        max-width: 1100px;
+        margin-left: auto;
+        margin-right: auto;
         
         .hero-stat {
             display: flex;
@@ -236,9 +242,9 @@ body {
             gap: 0.5rem;
             background: rgba(255, 255, 255, 0.1);
             backdrop-filter: blur(10px);
-            padding: 0.875rem 1.75rem;
+            padding: 0.75rem 1.5rem;
             border-radius: 50px;
-            font-size: 0.95rem;
+            font-size: 0.9rem;
             border: 1px solid rgba(255, 255, 255, 0.2);
             transition: all 0.3s ease;
             
@@ -293,11 +299,11 @@ body {
         margin: -20px -20px 3rem -20px;
         
         .hero-title {
-            font-size: 2rem;
+            font-size: 1.875rem;
         }
         
         .hero-subtitle {
-            font-size: 1.125rem;
+            font-size: 1.0625rem;
         }
         
         .hero-stats {

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -208,13 +208,16 @@ body {
         }
         
         .btn-ghost {
-            background: transparent;
+            background: rgba(255, 255, 255, 0.15);
             color: white;
-            border: 2px solid rgba(255, 255, 255, 0.3);
+            border: 2px solid rgba(255, 255, 255, 0.8);
+            backdrop-filter: blur(10px);
+            font-weight: 600;
             
             &:hover {
-                background: rgba(255, 255, 255, 0.1);
+                background: rgba(255, 255, 255, 0.25);
                 border-color: white;
+                transform: translateY(-1px);
             }
         }
     }
@@ -447,13 +450,16 @@ body {
             
             .btn {
                 &.btn-ghost {
-                    background: transparent;
+                    background: rgba(255, 255, 255, 0.15);
                     color: white;
-                    border: 2px solid white;
+                    border: 2px solid rgba(255, 255, 255, 0.8);
+                    backdrop-filter: blur(10px);
+                    font-weight: 600;
                     
                     &:hover {
-                        background: white;
+                        background: rgba(255, 255, 255, 0.95);
                         color: var(--primary-color);
+                        border-color: white;
                     }
                 }
             }
@@ -665,15 +671,32 @@ body {
     }
     
     &.btn-outline {
-        background: transparent;
+        background: rgba(255, 255, 255, 0.9);
         color: var(--primary-color);
         border-color: var(--primary-color);
+        font-weight: 600;
+        backdrop-filter: blur(10px);
         
         &:hover {
-            background: var(--primary-color);
-            color: white;
+            background: white;
+            transform: translateY(-1px);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
             text-decoration: none;
         }
+    }
+}
+
+// Dark background button variants (for better contrast)
+.hero-section .btn-outline,
+.cta-section .btn-outline {
+    background: rgba(255, 255, 255, 0.95);
+    color: var(--primary-color);
+    border-color: white;
+    font-weight: 600;
+    
+    &:hover {
+        background: white;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
     }
 }
 

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -123,7 +123,6 @@ body {
         border-radius: 8px;
         top: 100%;
         left: 0;
-        margin-top: 0.5rem;
         border: 1px solid var(--border-color);
         
         a {
@@ -135,6 +134,7 @@ body {
             
             &:first-child {
                 border-radius: 8px 8px 0 0;
+                padding-top: 1rem;  // Add visual spacing at the top
             }
             
             &:last-child {

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -157,31 +157,76 @@ body {
 .hero-section {
     background: var(--gradient);
     color: white;
-    padding: 5rem 0;
-    margin: -30px -30px 3rem -30px;
+    padding: 7rem 2rem 6rem;
+    margin: -30px -30px 4rem -30px;
     text-align: center;
+    position: relative;
+    overflow: hidden;
+    
+    // Add subtle animated background pattern
+    &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-image: 
+            radial-gradient(circle at 20% 50%, rgba(255, 255, 255, 0.1) 0%, transparent 50%),
+            radial-gradient(circle at 80% 80%, rgba(255, 255, 255, 0.05) 0%, transparent 50%),
+            radial-gradient(circle at 40% 20%, rgba(255, 255, 255, 0.05) 0%, transparent 50%);
+        pointer-events: none;
+        animation: float 20s ease-in-out infinite;
+    }
+    
+    @keyframes float {
+        0%, 100% { transform: translateY(0) rotate(0deg); }
+        33% { transform: translateY(-10px) rotate(1deg); }
+        66% { transform: translateY(5px) rotate(-1deg); }
+    }
+    
+    // Content wrapper
+    .hero-content {
+        position: relative;
+        max-width: 1000px;
+        margin: 0 auto;
+    }
+    
+    .hero-badge {
+        display: inline-block;
+        background: rgba(255, 255, 255, 0.2);
+        backdrop-filter: blur(10px);
+        padding: 0.5rem 1.25rem;
+        border-radius: 50px;
+        font-size: 0.875rem;
+        font-weight: 600;
+        margin-bottom: 2rem;
+        border: 1px solid rgba(255, 255, 255, 0.3);
+    }
     
     .hero-title {
-        font-size: 3.5rem;
+        font-size: clamp(2.5rem, 5vw, 4rem);
         font-weight: 700;
         margin-bottom: 1.5rem;
         line-height: 1.2;
+        letter-spacing: -0.02em;
     }
     
     .hero-subtitle {
-        font-size: 1.375rem;
-        margin-bottom: 2rem;
+        font-size: clamp(1.125rem, 2vw, 1.5rem);
+        margin-bottom: 3rem;
         opacity: 0.95;
         max-width: 800px;
         margin-left: auto;
         margin-right: auto;
         line-height: 1.6;
+        font-weight: 400;
     }
     
     .hero-stats {
         display: flex;
         justify-content: center;
-        gap: 2rem;
+        gap: 1.5rem;
         margin-bottom: 3rem;
         flex-wrap: wrap;
         
@@ -190,9 +235,17 @@ body {
             align-items: center;
             gap: 0.5rem;
             background: rgba(255, 255, 255, 0.1);
-            padding: 0.75rem 1.5rem;
+            backdrop-filter: blur(10px);
+            padding: 0.875rem 1.75rem;
             border-radius: 50px;
             font-size: 0.95rem;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            transition: all 0.3s ease;
+            
+            &:hover {
+                background: rgba(255, 255, 255, 0.15);
+                transform: translateY(-2px);
+            }
         }
     }
     
@@ -207,6 +260,18 @@ body {
             font-size: 1.125rem;
         }
         
+        .btn-primary {
+            background: white;
+            color: var(--primary-color);
+            font-weight: 600;
+            box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+            
+            &:hover {
+                transform: translateY(-2px);
+                box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
+            }
+        }
+        
         .btn-ghost {
             background: rgba(255, 255, 255, 0.15);
             color: white;
@@ -217,7 +282,42 @@ body {
             &:hover {
                 background: rgba(255, 255, 255, 0.25);
                 border-color: white;
-                transform: translateY(-1px);
+                transform: translateY(-2px);
+            }
+        }
+    }
+    
+    // Mobile responsiveness
+    @media (max-width: 768px) {
+        padding: 5rem 1.5rem 4rem;
+        margin: -20px -20px 3rem -20px;
+        
+        .hero-title {
+            font-size: 2rem;
+        }
+        
+        .hero-subtitle {
+            font-size: 1.125rem;
+        }
+        
+        .hero-stats {
+            flex-direction: column;
+            align-items: center;
+            gap: 1rem;
+            
+            .hero-stat {
+                width: 100%;
+                max-width: 400px;
+                justify-content: center;
+                text-align: center;
+                padding: 1rem 1.5rem;
+            }
+        }
+        
+        .hero-cta {
+            .btn-lg {
+                width: 100%;
+                max-width: 300px;
             }
         }
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,19 +4,22 @@ title: Home
 ---
 
 <div class="hero-section">
-  <h1 class="hero-title">Building a Database, Learning in Public</h1>
-  <p class="hero-subtitle"><strong>FerrisDB</strong>: Where a CRUD developer and an AI collaborate to build a real database from scratch, documenting every lesson learned along the way.</p>
-  
-  <div class="hero-stats">
-    <span class="hero-stat">🎯 <strong>Mission:</strong> Prove that anyone can understand database internals</span>
-    <span class="hero-stat">🤝 <strong>Approach:</strong> Human creativity + AI knowledge = Better learning</span>
-    <span class="hero-stat">📚 <strong>Result:</strong> The most transparent database development ever attempted</span>
-  </div>
-  
-  <div class="hero-cta">
-    <a href="{{ '/deep-dive/' | relative_url }}" class="btn btn-primary btn-lg">Start Learning</a>
-    <a href="{{ '/blog/' | relative_url }}" class="btn btn-outline btn-lg">Read Our Story</a>
-    <a href="#progress" class="btn btn-ghost btn-lg">View Progress</a>
+  <div class="hero-content">
+    <div class="hero-badge">🦀 Educational Project</div>
+    <h1 class="hero-title">Building a Database, Learning in Public</h1>
+    <p class="hero-subtitle"><strong>FerrisDB</strong>: Where a CRUD developer and an AI collaborate to build a real database from scratch, documenting every lesson learned along the way.</p>
+    
+    <div class="hero-stats">
+      <span class="hero-stat">🎯 <strong>Mission:</strong> Prove that anyone can understand database internals</span>
+      <span class="hero-stat">🤝 <strong>Approach:</strong> Human creativity + AI knowledge = Better learning</span>
+      <span class="hero-stat">📚 <strong>Result:</strong> The most transparent database development ever attempted</span>
+    </div>
+    
+    <div class="hero-cta">
+      <a href="{{ '/deep-dive/' | relative_url }}" class="btn btn-primary btn-lg">Start Learning</a>
+      <a href="{{ '/blog/' | relative_url }}" class="btn btn-outline btn-lg">Read Our Story</a>
+      <a href="#progress" class="btn btn-ghost btn-lg">View Progress</a>
+    </div>
   </div>
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,13 +8,12 @@ title: Home
     <div class="hero-badge">🦀 Educational Project</div>
     <h1 class="hero-title">Building a Database, Learning in Public</h1>
     <p class="hero-subtitle"><strong>FerrisDB</strong>: Where a CRUD developer and an AI collaborate to build a real database from scratch, documenting every lesson learned along the way.</p>
-    
     <div class="hero-stats">
       <span class="hero-stat">🎯 <strong>Mission:</strong> Prove that anyone can understand database internals</span>
       <span class="hero-stat">🤝 <strong>Approach:</strong> Human creativity + AI knowledge = Better learning</span>
       <span class="hero-stat">📚 <strong>Result:</strong> The most transparent database development ever attempted</span>
     </div>
-    
+
     <div class="hero-cta">
       <a href="{{ '/deep-dive/' | relative_url }}" class="btn btn-primary btn-lg">Start Learning</a>
       <a href="{{ '/blog/' | relative_url }}" class="btn btn-outline btn-lg">Read Our Story</a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,6 @@
 ---
 layout: home
 title: Home
-hero: true
 ---
 
 <div class="hero-section">


### PR DESCRIPTION
## Summary

Fixes the duplicate hero sections issue and improves the hero design based on feedback.

## Changes Made

- Removed \ from homepage front matter to fix duplicate hero sections
- Redesigned hero section for better visual integration:
  - Added educational project badge back (🦀 Educational Project)
  - Increased padding and improved spacing (7rem top, 6rem bottom)
  - Added subtle animated background pattern with radial gradients
  - Improved typography with responsive font sizes using clamp()
  - Enhanced mobile responsiveness with proper breakpoints
  - Better button contrast with shadows and backdrop blur
  - Wrapped content in max-width container for better readability
  - Fixed tight margins and boxy appearance with full-width extension

## Why This Matters

The home layout already includes a hero section when \ is set in the front matter. Our custom hero-section div was creating a duplicate. Additionally, the hero section needed visual improvements to feel more integrated with the page design.

## Testing

- Verified no duplicate hero sections on homepage
- All custom hero content displays correctly
- Buttons have proper contrast on gradient background
- Mobile responsiveness tested at various breakpoints
- Animated background pattern adds visual interest without distraction

## Breaking Changes

None