### PR TITLE
fix: Configure GitHub Actions for docs deployment

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,6 +5,7 @@ This directory contains all GitHub Actions workflows for the FerrisDB project.
 ## Workflows Overview
 
 ### CI (`ci.yml`)
+
 - **Triggers**: Push to main, pull requests, merge groups
 - **Purpose**: Run all continuous integration checks
 - **Jobs**:
@@ -18,7 +19,8 @@ This directory contains all GitHub Actions workflows for the FerrisDB project.
   - Security audit
 
 ### Deploy Docs (`deploy-docs.yml`)
-- **Triggers**: 
+
+- **Triggers**:
   - Push to main (only when docs/** or workflow changes)
   - Manual workflow dispatch
 - **Purpose**: Build and deploy documentation site to GitHub Pages
@@ -28,17 +30,21 @@ This directory contains all GitHub Actions workflows for the FerrisDB project.
 - **Note**: Requires GitHub Pages source to be set to "GitHub Actions" in repo settings
 
 ### PR Review Check (`pr-review-check.yml`)
+
 - **Purpose**: Enforce pull request review requirements
 
 ### Release (`release.yml`)
+
 - **Purpose**: Handle release automation
 
 ### Security (`security.yml`)
+
 - **Purpose**: Run security-specific checks
 
 ## No Conflicts
 
 The workflows are designed to work together without conflicts:
+
 - **CI** validates that the docs build correctly but doesn't deploy
 - **Deploy Docs** only runs after changes are merged to main and actually deploys the site
 - Both use the same Ruby/Jekyll setup for consistency
@@ -46,6 +52,7 @@ The workflows are designed to work together without conflicts:
 ## GitHub Pages Configuration
 
 After enabling the Deploy Docs workflow, ensure:
+
 1. Go to Settings → Pages
 2. Set Source to "GitHub Actions" (not "Deploy from a branch")
 3. Custom domain is already configured (CNAME file exists)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,51 @@
+# GitHub Actions Workflows
+
+This directory contains all GitHub Actions workflows for the FerrisDB project.
+
+## Workflows Overview
+
+### CI (`ci.yml`)
+- **Triggers**: Push to main, pull requests, merge groups
+- **Purpose**: Run all continuous integration checks
+- **Jobs**:
+  - Quick checks (formatting, clippy)
+  - Markdown linting
+  - Spell checking  
+  - Test suite (multiple OS and Rust versions)
+  - Documentation build (Rust docs)
+  - MSRV testing (1.81.0)
+  - Jekyll site build validation (builds but doesn't deploy)
+  - Security audit
+
+### Deploy Docs (`deploy-docs.yml`)
+- **Triggers**: 
+  - Push to main (only when docs/** or workflow changes)
+  - Manual workflow dispatch
+- **Purpose**: Build and deploy documentation site to GitHub Pages
+- **Jobs**:
+  - Build Jekyll site with just-the-docs theme
+  - Deploy to GitHub Pages using Actions
+- **Note**: Requires GitHub Pages source to be set to "GitHub Actions" in repo settings
+
+### PR Review Check (`pr-review-check.yml`)
+- **Purpose**: Enforce pull request review requirements
+
+### Release (`release.yml`)
+- **Purpose**: Handle release automation
+
+### Security (`security.yml`)
+- **Purpose**: Run security-specific checks
+
+## No Conflicts
+
+The workflows are designed to work together without conflicts:
+- **CI** validates that the docs build correctly but doesn't deploy
+- **Deploy Docs** only runs after changes are merged to main and actually deploys the site
+- Both use the same Ruby/Jekyll setup for consistency
+
+## GitHub Pages Configuration
+
+After enabling the Deploy Docs workflow, ensure:
+1. Go to Settings → Pages
+2. Set Source to "GitHub Actions" (not "Deploy from a branch")
+3. Custom domain is already configured (CNAME file exists)

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,59 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+          working-directory: ./docs
+          
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+        
+      - name: Build with Jekyll
+        run: |
+          cd docs
+          bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+          
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs/_site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,7 @@ title: FerrisDB
 description: >-
   Educational distributed database in Rust - Learning LSM-trees, MVCC, 
   and distributed systems with Claude Code. Inspired by FoundationDB.
-baseurl: "/"
+baseurl: ""
 url: "https://ferrisdb.org"
 github_username: ferrisdb
 repository: ferrisdb/ferrisdb


### PR DESCRIPTION
## Summary

Fix GitHub Pages deployment error by switching from default GitHub Pages build to GitHub Actions workflow.

## Problem

GitHub Pages default build doesn't support the `just-the-docs` gem in the Gemfile, resulting in:
```
Bundler can't satisfy your Gemfile's dependencies.
```

## Solution

Implement GitHub Actions workflow for building and deploying the docs site, which allows us to use any Jekyll theme and gems.

## Changes Made

- Add `.github/workflows/deploy-docs.yml` workflow to build and deploy docs
- Fix baseurl configuration in `_config.yml` 
- Add `.nojekyll` file to prevent default Jekyll processing
- Add workflow README documenting all workflows and confirming no conflicts
- Workflow triggers on pushes to main that modify docs or the workflow itself

## Workflow Integration

- **No conflicts** with existing CI workflow
- CI workflow () already validates Jekyll builds but doesn't deploy
- New deploy workflow only handles actual deployment to GitHub Pages
- Both workflows use same Ruby/Jekyll setup for consistency

## Next Steps

After merging, you'll need to:
1. Go to Settings → Pages in the GitHub repo
2. Under "Build and deployment", change Source from "Deploy from a branch" to "GitHub Actions"
3. The workflow will then run automatically on the next push to main

## Testing

The workflow will be tested when it runs after merge. It uses the standard GitHub Pages deployment actions.