### PR TITLE
fix: Fix TOC formatting across all documentation pages

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,8 +5,6 @@ nav_order: 8
 permalink: /architecture/
 ---
 
-{: .no_toc }
-
 Comprehensive design document for FerrisDB's distributed database architecture
 {: .fs-6 .fw-300 }
 
@@ -15,7 +13,7 @@ Comprehensive design document for FerrisDB's distributed database architecture
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/deep-dive/concurrent-skip-list.md
+++ b/docs/deep-dive/concurrent-skip-list.md
@@ -17,7 +17,7 @@ Understanding concurrent programming through FerrisDB's MemTable implementation
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/deep-dive/lsm-trees.md
+++ b/docs/deep-dive/lsm-trees.md
@@ -17,7 +17,7 @@ Understanding Log-Structured Merge Trees through FerrisDB's implementation
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/deep-dive/sstable-design.md
+++ b/docs/deep-dive/sstable-design.md
@@ -17,7 +17,7 @@ How databases organize and access data on disk for optimal performance
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/deep-dive/wal-crash-recovery.md
+++ b/docs/deep-dive/wal-crash-recovery.md
@@ -17,7 +17,7 @@ How Write-Ahead Logs ensure data durability and enable crash recovery in databas
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,8 +5,6 @@ nav_order: 6
 permalink: /faq/
 ---
 
-{: .no_toc }
-
 Everything you want to know about FerrisDB and our human-AI collaboration
 {: .fs-6 .fw-300 }
 
@@ -15,7 +13,7 @@ Everything you want to know about FerrisDB and our human-AI collaboration
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/future-architecture.md
+++ b/docs/future-architecture.md
@@ -1,8 +1,20 @@
 ---
-layout: page
+layout: default
 title: Future Architecture Explorations
-subtitle: Advanced concepts and research directions for FerrisDB evolution
+nav_exclude: true
 permalink: /future-architecture/
+---
+
+Advanced concepts and research directions for FerrisDB evolution
+{: .fs-6 .fw-300 }
+
+## Table of contents
+
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
 ---
 
 This page documents interesting architectural patterns and advanced concepts we might explore as FerrisDB evolves from an educational project toward production-ready capabilities.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,8 +5,6 @@ nav_order: 2
 permalink: /getting-started/
 ---
 
-{: .no_toc }
-
 How to build, run, and contribute to FerrisDB
 {: .fs-6 .fw-300 }
 
@@ -15,7 +13,7 @@ How to build, run, and contribute to FerrisDB
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/rust-by-example/ownership-memtable-sharing.md
+++ b/docs/rust-by-example/ownership-memtable-sharing.md
@@ -6,8 +6,6 @@ nav_order: 1
 permalink: /rust-by-example/ownership-memtable-sharing/
 ---
 
-{: .no_toc }
-
 Understanding Rust ownership through FerrisDB's MemTable, compared with JavaScript, Python, Java, and Go
 {: .fs-6 .fw-300 }
 
@@ -19,7 +17,7 @@ Understanding Rust ownership through FerrisDB's MemTable, compared with JavaScri
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/storage-engine.md
+++ b/docs/storage-engine.md
@@ -1,8 +1,20 @@
 ---
-layout: page
+layout: default
 title: Storage Engine Design
-subtitle: Detailed design and implementation of FerrisDB's custom LSM-tree storage engine
+nav_exclude: true
 permalink: /storage-engine/
+---
+
+Detailed design and implementation of FerrisDB's custom LSM-tree storage engine
+{: .fs-6 .fw-300 }
+
+## Table of contents
+
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary

Fix Table of Contents (TOC) issues across all documentation pages to ensure proper navigation functionality with Just the Docs theme.

## Problem

The TOC wasn't working correctly on many pages due to:
- Incorrect TOC syntax with indentation
- Missing TOC on some pages
- Inconsistent layout usage

## Solution

### TOC Syntax Fix
- Changed from:
  ```markdown
  1. TOC
     {:toc}
  ```
- To:
  ```markdown
  1. TOC
  {:toc}
  ```
- The indentation was preventing Just the Docs from recognizing the TOC directive

### Pages Updated
- **Deep Dive Articles** (4 files): wal-crash-recovery, lsm-trees, sstable-design, concurrent-skip-list
- **Main Pages**: getting-started, architecture, faq
- **Additional Pages**: storage-engine, future-architecture  
- **Rust by Example**: ownership-memtable-sharing

### Additional Improvements
- Added TOC to storage-engine.md and future-architecture.md
- Changed layout from 'page' to 'default' for consistency
- Added 'nav_exclude: true' for pages not in main navigation
- Fixed all markdown linting issues (0 errors)

## Testing

- ✅ All TOCs now render correctly
- ✅ Navigation within pages works
- ✅ Markdown linting passes with 0 errors
- ✅ Consistent behavior across all documentation pages

This ensures readers can easily navigate long documentation pages with a working table of contents.