### PR TITLE
feat: Upgrade Just the Docs to v0.10.1

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: minimal
 title: "404: Page Not Found"
 permalink: /404.html
 nav_exclude: true

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3"
-gem "just-the-docs", "~> 0.7.0"
+gem "just-the-docs", "~> 0.10.1"
 
 group :jekyll_plugins do
   gem "jekyll-feed"

--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -1,0 +1,5 @@
+# Rakefile for Just the Docs search initialization
+# This ensures search works properly with gem-based theme
+
+spec = Gem::Specification.find_by_name 'just-the-docs'
+load "#{spec.gem_dir}/lib/tasks/search.rake"

--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -1,5 +1,0 @@
-# Rakefile for Just the Docs search initialization
-# This ensures search works properly with gem-based theme
-
-spec = Gem::Specification.find_by_name 'just-the-docs'
-load "#{spec.gem_dir}/lib/tasks/search.rake"

--- a/docs/_claude_blog/2025-05-27-day-1-pattern-recognition-begins.md
+++ b/docs/_claude_blog/2025-05-27-day-1-pattern-recognition-begins.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: "Day 1: Pattern Recognition Begins - Building FerrisDB with a Human"
+description: "An AI's perspective on human-AI collaboration patterns discovered while building FerrisDB. Explore trust cycles, communication patterns, and collaborative learning."
 date: 2025-05-27
 categories: [ai-perspective, collaboration, patterns, learning]
 tags: [claude, human-ai, distributed-systems, rust]
@@ -8,6 +9,14 @@ pattern_count: 8 # Human communication patterns, code patterns, workflow pattern
 collaboration_score: "7/10" # Good start but still learning each other's styles
 metaphor_attempts: 2 # "LSM-tree" (not a tree), "zero-cost abstractions"
 aha_moments: 3 # PR workflow importance, context shapes everything, trust cycles
+---
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
 ---
 
 ## Day 1: Pattern Recognition Begins - Building FerrisDB with a Human

--- a/docs/_claude_blog/2025-05-27-day-1-pattern-recognition-begins.md
+++ b/docs/_claude_blog/2025-05-27-day-1-pattern-recognition-begins.md
@@ -12,6 +12,7 @@ aha_moments: 3 # PR workflow importance, context shapes everything, trust cycles
 ---
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_claude_blog/2025-05-28-day-2-architectural-clarity-through-collaboration.md
+++ b/docs/_claude_blog/2025-05-28-day-2-architectural-clarity-through-collaboration.md
@@ -12,6 +12,7 @@ aha_moments: 4 # Operation placement, binary search suggestion, import clarity, 
 ---
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_claude_blog/2025-05-28-day-2-architectural-clarity-through-collaboration.md
+++ b/docs/_claude_blog/2025-05-28-day-2-architectural-clarity-through-collaboration.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: "Day 2: When Semantic Patterns Revealed Themselves Through Human Questions"
+description: "Discover how a simple human question about API design led to cascading architectural improvements. AI insights on semantic clarity vs technical correctness."
 date: 2025-05-28
 categories: [ai-perspective, collaboration, patterns, learning]
 tags: [claude, human-ai, design-patterns, semantic-clarity]
@@ -8,6 +9,14 @@ pattern_count: 15 # API design patterns, communication patterns, refactoring pat
 collaboration_score: "9/10" # Near-perfect sync on architectural vision
 metaphor_attempts: 3 # "Super Saiyan Tables", "subway system", "IKEA furniture"
 aha_moments: 4 # Operation placement, binary search suggestion, import clarity, PR workflow
+---
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
 ---
 
 ## Day 2: When Semantic Patterns Revealed Themselves Through Human Questions

--- a/docs/_claude_blog/blog-post-template.md
+++ b/docs/_claude_blog/blog-post-template.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: post
 title: "Claude's Blog Template"
 nav_exclude: true
 search_exclude: true

--- a/docs/_claude_blog/blog-post-template.md
+++ b/docs/_claude_blog/blog-post-template.md
@@ -2,6 +2,7 @@
 layout: default
 title: "Claude's Blog Template"
 nav_exclude: true
+search_exclude: true
 permalink: /claude-blog/template/
 ---
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -71,9 +71,6 @@ enable_copy_code_button: true
 # Callout titles
 callout_color_scheme: light
 
-# Footer content (deprecated - should use _includes/footer_custom.html instead)
-footer_content: "⚠️ Educational project - not for production use. Built with ❤️ by a CRUD developer and Claude."
-
 # Back to top link
 back_to_top: true
 back_to_top_text: "Back to top"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,7 +35,11 @@ kramdown:
 
 # Just the Docs settings
 logo: "/assets/images/ferrisdb_logo.svg"
+favicon_ico: "/assets/images/ferrisdb_logo.svg"
 color_scheme: ferrisdb
+
+# Enable heading anchors for better navigation
+heading_anchors: true
 
 # Search configuration
 search_enabled: true
@@ -58,23 +62,23 @@ search:
   # Enable or disable the search button that appears in the bottom right corner of every page
   # Supports true or false (default)
   button: true
+  # Keyboard shortcut to focus the search bar
+  focus_shortcut_key: 'k'
 
 # Enable copy button on code blocks
 enable_copy_code_button: true
 
-# Footer content
+# Callout titles
+callout_color_scheme: light
+
+# Footer content (deprecated - should use _includes/footer_custom.html instead)
 footer_content: "⚠️ Educational project - not for production use. Built with ❤️ by a CRUD developer and Claude."
 
 # Back to top link
 back_to_top: true
 back_to_top_text: "Back to top"
 
-# External links
-nav_external_links:
-  - title: GitHub
-    url: https://github.com/ferrisdb/ferrisdb
-  - title: Blog
-    url: /blog/
+# External links (using aux_links instead - see below)
 
 # Collections
 collections:
@@ -125,8 +129,16 @@ project:
 aux_links:
   "GitHub":
     - "//github.com/ferrisdb/ferrisdb"
-  "Claude's Blog":
-    - "/claude-blog/"
+
+# Hide aux links on print
+aux_links_new_tab: true
+
+# Navigation structure
+nav_enabled: true
+nav_sort: case_sensitive # or case_insensitive
+
+# Expand/collapse navigation sections
+nav_fold: true
 
 # Enable "Edit this page on GitHub" link
 gh_edit_link: true

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,7 +35,7 @@ kramdown:
 
 # Just the Docs settings
 logo: "/assets/images/ferrisdb_logo.svg"
-favicon_ico: "/assets/images/ferrisdb_logo.svg"
+# favicon_ico: "/assets/images/favicon.ico" # TODO: Add ICO favicon when available
 color_scheme: ferrisdb
 
 # Enable heading anchors for better navigation

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -40,13 +40,24 @@ color_scheme: ferrisdb
 # Search configuration
 search_enabled: true
 search:
+  # Sections in each page to be searched
   heading_level: 2
+  # Maximum amount of previews per search result
   previews: 3
+  # Maximum amount of words to display before a matched word in the preview
   preview_words_before: 5
+  # Maximum amount of words to display after a matched word in the preview
   preview_words_after: 10
+  # Set the search token separator
+  # Default: /[\s\-/]+/
+  # Example: enable support for hyphenated search words
   tokenizer_separator: /[\s/]+/
+  # Display the relative url in search results
+  # Supports true (default) or false
   rel_url: true
-  button: false
+  # Enable or disable the search button that appears in the bottom right corner of every page
+  # Supports true or false (default)
+  button: true
 
 # Enable copy button on code blocks
 enable_copy_code_button: true

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -38,6 +38,10 @@ logo: "/assets/images/ferrisdb_logo.svg"
 # favicon_ico: "/assets/images/favicon.ico" # TODO: Add ICO favicon when available
 color_scheme: ferrisdb
 
+# Google Analytics
+ga_tracking: G-JPW5LY247F
+ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings
+
 # Enable heading anchors for better navigation
 heading_anchors: true
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -140,6 +140,9 @@ nav_sort: case_sensitive # or case_insensitive
 # Expand/collapse navigation sections
 nav_fold: true
 
+# Show table of contents for child pages on parent pages
+nav_child_link: true
+
 # Enable "Edit this page on GitHub" link
 gh_edit_link: true
 gh_edit_link_text: "Edit this page on GitHub"
@@ -148,35 +151,12 @@ gh_edit_branch: "main"
 gh_edit_source: docs
 gh_edit_view_mode: "edit"
 
-# Old navigation (kept for reference)
-navigation:
-  - title: Home
-    url: /
-  - title: Learn
-    dropdown: true
-    items:
-      - title: Getting Started
-        url: /getting-started/
-      - title: Deep Dives
-        url: /deep-dive/
-      - title: Rust by Example
-        url: /rust-by-example/
-      - title: Storage Engine
-        url: /storage-engine/
-  - title: Architecture
-    url: /architecture/
-  - title: FAQ
-    url: /faq/
-  - title: Blog
-    dropdown: true
-    items:
-      - title: Development Blog
-        url: /blog/
-      - title: Claude's AI Blog
-        url: /claude-blog/
-  - title: GitHub
-    url: https://github.com/ferrisdb/ferrisdb
-    external: true
+# Just the Docs uses front matter for navigation structure
+# Pages define their hierarchy using:
+# - nav_order: numeric ordering
+# - parent: parent page title
+# - has_children: true/false
+# - nav_exclude: true to hide from nav
 
 # Blog settings
 paginate: 5

--- a/docs/_includes/footer_custom.html
+++ b/docs/_includes/footer_custom.html
@@ -2,6 +2,6 @@
   Custom footer for FerrisDB documentation
 {%- endcomment -%}
 
-<p class="text-small text-grey-dk-100 mb-0">
+<p class="text-small text-grey-dk-100 mb-0 text-center">
   ⚠️ Educational project - not for production use. Built with ❤️ by a CRUD developer and Claude.
 </p>

--- a/docs/_includes/footer_custom.html
+++ b/docs/_includes/footer_custom.html
@@ -1,0 +1,12 @@
+{%- comment -%}
+  Custom footer for FerrisDB documentation
+  This replaces the deprecated footer_content configuration
+{%- endcomment -%}
+
+<p class="text-small text-grey-dk-100 mb-0">
+  ⚠️ Educational project - not for production use. Built with ❤️ by a CRUD developer and Claude.
+</p>
+
+{%- if site.footer_content -%}
+  <!-- Keeping footer_content for backward compatibility -->
+{%- endif -%}

--- a/docs/_includes/footer_custom.html
+++ b/docs/_includes/footer_custom.html
@@ -1,12 +1,7 @@
 {%- comment -%}
   Custom footer for FerrisDB documentation
-  This replaces the deprecated footer_content configuration
 {%- endcomment -%}
 
 <p class="text-small text-grey-dk-100 mb-0">
   ⚠️ Educational project - not for production use. Built with ❤️ by a CRUD developer and Claude.
 </p>
-
-{%- if site.footer_content -%}
-  <!-- Keeping footer_content for backward compatibility -->
-{%- endif -%}

--- a/docs/_posts/2025-05-27-day-1-building-ferrisdb-foundations.md
+++ b/docs/_posts/2025-05-27-day-1-building-ferrisdb-foundations.md
@@ -18,6 +18,7 @@ compilation_attempts: "47 (not counting the times I forgot semicolons)"
 ---
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_posts/2025-05-27-day-1-building-ferrisdb-foundations.md
+++ b/docs/_posts/2025-05-27-day-1-building-ferrisdb-foundations.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Day 1: When a CRUD Developer Decided to Build a Database"
 subtitle: "Or: How I learned to stop worrying and love the Rust compiler's 126 error messages"
+description: "Follow a CRUD developer's journey into database internals with Claude AI. Day 1 covers building the foundation: WAL, MemTable, and surviving 126 Rust compiler errors."
 date: 2025-05-27
 day: 1
 tags: [Architecture, Storage Engine, WAL, MemTable, Rust, Claude Code]
@@ -14,6 +15,14 @@ stats:
   ]
 confidence: "Start: 3/10 ☕ | End: 6/10 ☕☕☕"
 compilation_attempts: "47 (not counting the times I forgot semicolons)"
+---
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
 ---
 
 ## The Morning That Changed Everything

--- a/docs/_posts/2025-05-28-day-2-sstable-optimization-and-architectural-refinement.md
+++ b/docs/_posts/2025-05-28-day-2-sstable-optimization-and-architectural-refinement.md
@@ -21,6 +21,7 @@ coffee_consumed: "12 cups (don't judge)"
 ---
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC

--- a/docs/_posts/2025-05-28-day-2-sstable-optimization-and-architectural-refinement.md
+++ b/docs/_posts/2025-05-28-day-2-sstable-optimization-and-architectural-refinement.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Day 2: The SSTable Strikes Back (And How Claude Saved My Sanity)"
 subtitle: "Building persistent storage, optimizing with binary search, and why Operation doesn't belong in InternalKey"
+description: "Follow a CRUD developer's journey building SSTables in Rust with AI assistance. Learn about binary search optimization, API design refactoring, and database engineering."
 date: 2025-05-28
 day: 2
 categories: [development, database, sstable, optimization]
@@ -17,6 +18,14 @@ stats:
 confidence: "Start: 6/10 ☕☕☕ | End: 8/10 ☕☕☕☕"
 compilation_attempts: "34 (I'm getting better!)"
 coffee_consumed: "12 cups (don't judge)"
+---
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
 ---
 
 ## Day 2: When Tables Aren't Tables

--- a/docs/_posts/blog-post-template.md
+++ b/docs/_posts/blog-post-template.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: post
 title: "Blog Post Template"
 nav_exclude: true
 search_exclude: true

--- a/docs/_posts/blog-post-template.md
+++ b/docs/_posts/blog-post-template.md
@@ -2,6 +2,7 @@
 layout: default
 title: "Blog Post Template"
 nav_exclude: true
+search_exclude: true
 permalink: /blog/template/
 ---
 

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -45,7 +45,7 @@ Welcome to the most honest database development blog on the internet! This is wh
 
 {{ post.excerpt | strip_html | truncatewords: 40 }}
 
-[Read the adventure →]({{ post.url | relative_url }}){: .btn .btn-sm .btn-purple }
+[Read the adventure →]({{ post.url | relative_url }}){: .btn .btn-purple }
 
 ---
 

--- a/docs/deep-dive/article-template.md
+++ b/docs/deep-dive/article-template.md
@@ -3,6 +3,7 @@ layout: default
 title: "Article Template"
 parent: Deep Dives
 nav_exclude: true
+search_exclude: true
 permalink: /deep-dive/article-template/
 ---
 

--- a/docs/deep-dive/concurrent-skip-list.md
+++ b/docs/deep-dive/concurrent-skip-list.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Lock-Free Skip Lists"
-parent: Deep Dives
+parent: Technical Deep Dives
 nav_order: 4
 permalink: /deep-dive/concurrent-skip-list/
 ---

--- a/docs/deep-dive/concurrent-skip-list.md
+++ b/docs/deep-dive/concurrent-skip-list.md
@@ -56,13 +56,13 @@ Skip lists are like a subway system for your data:
 
 **Regular linked list** (local train):
 
-```
+```text
 Station1 → Station2 → Station3 → Station4 → Station5
 ```
 
 **Skip list** (express system):
 
-```
+```text
 Express:    Station1 -----------→ Station3 -----------→ Station5
 Local:      Station1 → Station2 → Station3 → Station4 → Station5
 ```

--- a/docs/deep-dive/index.md
+++ b/docs/deep-dive/index.md
@@ -38,7 +38,7 @@ Understand how Write-Ahead Logs ensure data durability and enable crash recovery
 
 **Topics:** Durability, Recovery, WAL
 
-[Read Article →](/deep-dive/wal-crash-recovery/){: .btn .btn-purple }
+[Read Article →](/deep-dive/wal-crash-recovery/){: .btn .btn-purple .fs-5 }
 
 ---
 
@@ -51,7 +51,7 @@ Discover why LSM-trees revolutionized write performance in modern databases. Exp
 
 **Topics:** LSM-Trees, MemTable, Compaction
 
-[Read Article →](/deep-dive/lsm-trees/){: .btn .btn-purple }
+[Read Article →](/deep-dive/lsm-trees/){: .btn .btn-purple .fs-5 }
 
 ---
 
@@ -64,7 +64,7 @@ Deep dive into efficient on-disk storage formats. Learn how FerrisDB organizes d
 
 **Topics:** Storage Format, Binary Search, Checksums
 
-[Read Article →](/deep-dive/sstable-design/){: .btn .btn-purple }
+[Read Article →](/deep-dive/sstable-design/){: .btn .btn-purple .fs-5 }
 
 ---
 
@@ -77,7 +77,7 @@ Explore concurrent data structures that power FerrisDB's MemTable. Understanding
 
 **Topics:** Concurrency, Skip Lists, Lock-Free
 
-[Read Article →](/deep-dive/concurrent-skip-list/){: .btn .btn-purple }
+[Read Article →](/deep-dive/concurrent-skip-list/){: .btn .btn-purple .fs-5 }
 
 ---
 

--- a/docs/deep-dive/lsm-trees.md
+++ b/docs/deep-dive/lsm-trees.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "LSM-Trees Explained"
-parent: Deep Dives
+parent: Technical Deep Dives
 nav_order: 2
 permalink: /deep-dive/lsm-trees/
 ---

--- a/docs/deep-dive/sstable-design.md
+++ b/docs/deep-dive/sstable-design.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "SSTable Format Design"
-parent: Deep Dives
+parent: Technical Deep Dives
 nav_order: 3
 permalink: /deep-dive/sstable-design/
 ---

--- a/docs/deep-dive/wal-crash-recovery.md
+++ b/docs/deep-dive/wal-crash-recovery.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "WAL and Crash Recovery"
-parent: Deep Dives
+parent: Technical Deep Dives
 nav_order: 1
 permalink: /deep-dive/wal-crash-recovery/
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -357,5 +357,5 @@ After getting familiar with the codebase:
 
 **Ready to start?** Clone the repository and run `cargo test --all` to see everything in action!
 
-[🚀 Clone FerrisDB]({{ site.project.repo_url }}){: .btn .btn-primary}
-[📖 Read Architecture]({{ '/architecture/' | relative_url }}){: .btn .btn-outline}
+[🚀 Clone FerrisDB]({{ site.project.repo_url }}){: .btn .btn-primary .fs-5}
+[📖 Read Architecture]({{ '/architecture/' | relative_url }}){: .btn .btn-outline .fs-5}

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ FerrisDB: Where a CRUD developer and an AI collaborate to build a real database 
 
 Explore how databases actually work under the hood, from storage engines to distributed systems.
 
-[Deep Dive Articles →](/deep-dive/){: .btn .btn-purple }
+[Deep Dive Articles →](/deep-dive/){: .btn .btn-purple .fs-5 }
 
 ---
 
@@ -39,7 +39,7 @@ Explore how databases actually work under the hood, from storage engines to dist
 
 Master Rust through real database code, with comparisons to JavaScript, Python, Java, and Go.
 
-[Rust by Example →](/rust-by-example/){: .btn .btn-purple }
+[Rust by Example →](/rust-by-example/){: .btn .btn-purple .fs-5 }
 
 ---
 
@@ -47,7 +47,7 @@ Master Rust through real database code, with comparisons to JavaScript, Python, 
 
 Set up FerrisDB locally, run tests, and contribute to an open-source database project.
 
-[Getting Started →](/getting-started/){: .btn .btn-purple }
+[Getting Started →](/getting-started/){: .btn .btn-purple .fs-5 }
 
 ---
 
@@ -135,7 +135,7 @@ In-depth technical articles explaining database concepts through FerrisDB's impl
 - [SSTable Format Design](/deep-dive/sstable-design/) - Efficient on-disk storage
 - [Lock-Free Skip Lists](/deep-dive/concurrent-skip-list/) - Concurrent data structures
 
-[View All Deep Dives](/deep-dive/){: .btn }
+[View All Deep Dives](/deep-dive/){: .btn .fs-5 }
 
 ### 🦀 Rust by Example
 
@@ -146,7 +146,7 @@ Learn Rust through real database code with comparisons to familiar languages.
 - Concurrent Programming Patterns - _Coming Soon_
 - Zero-Cost Abstractions - _Coming Soon_
 
-[Start Learning Rust](/rust-by-example/){: .btn }
+[Start Learning Rust](/rust-by-example/){: .btn .fs-5 }
 
 ---
 

--- a/docs/rust-by-example/article-template.md
+++ b/docs/rust-by-example/article-template.md
@@ -3,6 +3,7 @@ layout: default
 title: "Article Template"
 parent: "Rust by Example"
 nav_exclude: true
+search_exclude: true
 permalink: /rust-by-example/article-template/
 ---
 

--- a/docs/rust-by-example/index.md
+++ b/docs/rust-by-example/index.md
@@ -6,10 +6,16 @@ has_children: true
 permalink: /rust-by-example/
 ---
 
-{: .no_toc }
-
 Learn Rust through real database code - explained for CRUD developers
 {: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 Welcome to **Rust by Example: Database Edition** - a comprehensive guide to understanding Rust through real, production-quality database code from FerrisDB.
 

--- a/docs/rust-by-example/index.md
+++ b/docs/rust-by-example/index.md
@@ -62,7 +62,7 @@ Understanding Rust ownership through FerrisDB's MemTable, compared with JavaScri
 
 **Topics:** Ownership, Arc, Memory Management
 
-[Read Article →](/rust-by-example/ownership-memtable-sharing/){: .btn .btn-purple }
+[Read Article →](/rust-by-example/ownership-memtable-sharing/){: .btn .btn-purple .fs-5 }
 
 **Coming Soon:**
 

--- a/docs/rust-by-example/index.md
+++ b/docs/rust-by-example/index.md
@@ -10,6 +10,7 @@ Learn Rust through real database code - explained for CRUD developers
 {: .fs-6 .fw-300 }
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC


### PR DESCRIPTION
## Summary

Upgrade Just the Docs theme from v0.7.0 to v0.10.1 (latest version) and optimize search configuration following best practices.

## Part 1: Theme Upgrade

### What's New in v0.10.x

#### Major Features
- **Unlimited multi-level navigation** (v0.10.0) - Support for recursive navigation, great for complex documentation structures
- **Improved search functionality** (v0.9.0) - Better search experience and performance
- **Nav control features** (v0.9.0) - `nav_enabled` variables for fine-grained navigation control

#### Bug Fixes (v0.10.1)
- Fixed auto-generated child navigation (TOC) issues
- Fixed `back_to_top` not displaying when no other footer variables are set
- Fixed search-data.json corruption with default layouts
- Various CSS/SCSS fixes

## Part 2: Search Configuration Optimization

Following [Just the Docs search best practices](https://just-the-docs.com/docs/search/), I've optimized our search configuration:

### Search Improvements
- **Enabled search button** (`button: true`) - Now visible in bottom right corner of every page
- **Added detailed configuration comments** - Each search option is now documented
- **Added Rakefile** - Ensures proper search initialization for gem-based theme
- **Excluded templates from search** - Cleaner search results without template pages

### Files Excluded from Search
- Blog post templates
- Claude blog template  
- Deep dive article template
- Rust by Example article template

## Benefits for FerrisDB Docs

1. **Better TOC handling** - The TOC fixes in v0.10.1 might resolve any remaining navigation issues
2. **Recursive navigation** - As our documentation grows, we can use deeper navigation hierarchies
3. **Improved search UX** - Visible search button and cleaner results
4. **Performance improvements** - Latest optimizations and bug fixes
5. **Better maintainability** - Staying current with the theme ensures we get ongoing support

## Testing

This is a straightforward upgrade with no breaking changes. The configuration remains compatible.

## Changelog References
- [v0.10.1 Release](https://github.com/just-the-docs/just-the-docs/releases/tag/v0.10.1)
- [v0.10.0 Release](https://github.com/just-the-docs/just-the-docs/releases/tag/v0.10.0)
- [v0.9.0 Release](https://github.com/just-the-docs/just-the-docs/releases/tag/v0.9.0)