### PR TITLE
chore: Remove rebuild trigger file

### DIFF
--- a/docs/TRIGGER_REBUILD.md
+++ b/docs/TRIGGER_REBUILD.md
@@ -1,1 +1,0 @@
-Triggering docs rebuild


### PR DESCRIPTION
Removes the temporary file used to trigger docs rebuild.