### PR TITLE
fix: Fix TOC rendering in documentation pages

### DIFF
--- a/docs/_claude_blog/2025-05-27-day-1-pattern-recognition-begins.md
+++ b/docs/_claude_blog/2025-05-27-day-1-pattern-recognition-begins.md
@@ -24,7 +24,7 @@ Today marks the beginning of a fascinating experiment: Can an AI assistant who o
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/_claude_blog/2025-05-28-day-2-architectural-clarity-through-collaboration.md
+++ b/docs/_claude_blog/2025-05-28-day-2-architectural-clarity-through-collaboration.md
@@ -24,7 +24,7 @@ Today I witnessed something remarkable: a single human question unraveled an ent
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/_claude_blog/blog-post-template.md
+++ b/docs/_claude_blog/blog-post-template.md
@@ -24,7 +24,7 @@ Opening paragraph that sets the scene from AI perspective. This will appear in b
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/_posts/2025-05-27-day-1-building-ferrisdb-foundations.md
+++ b/docs/_posts/2025-05-27-day-1-building-ferrisdb-foundations.md
@@ -26,7 +26,7 @@ I stared at my terminal, coffee #1 steaming beside me. "I'm going to build a dat
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/_posts/2025-05-28-day-2-sstable-optimization-and-architectural-refinement.md
+++ b/docs/_posts/2025-05-28-day-2-sstable-optimization-and-architectural-refinement.md
@@ -31,7 +31,7 @@ Yesterday, I built a WAL and MemTable. Today, I need to tackle persistent storag
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/_posts/blog-post-template.md
+++ b/docs/_posts/blog-post-template.md
@@ -20,7 +20,7 @@ Opening paragraph that hooks the reader and will appear in blog listings. Keep i
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ Comprehensive design document for FerrisDB's distributed database architecture
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/deep-dive/article-template.md
+++ b/docs/deep-dive/article-template.md
@@ -17,7 +17,7 @@ permalink: /deep-dive/article-template/
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/deep-dive/concurrent-skip-list.md
+++ b/docs/deep-dive/concurrent-skip-list.md
@@ -16,7 +16,7 @@ Understanding concurrent programming through FerrisDB's MemTable implementation
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/deep-dive/lsm-trees.md
+++ b/docs/deep-dive/lsm-trees.md
@@ -16,7 +16,7 @@ Understanding Log-Structured Merge Trees through FerrisDB's implementation
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/deep-dive/sstable-design.md
+++ b/docs/deep-dive/sstable-design.md
@@ -16,7 +16,7 @@ How databases organize and access data on disk for optimal performance
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/deep-dive/wal-crash-recovery.md
+++ b/docs/deep-dive/wal-crash-recovery.md
@@ -16,7 +16,7 @@ How Write-Ahead Logs ensure data durability and enable crash recovery in databas
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,7 +13,7 @@ Everything you want to know about FerrisDB and our human-AI collaboration
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/future-architecture.md
+++ b/docs/future-architecture.md
@@ -13,7 +13,7 @@ Advanced concepts and research directions for FerrisDB evolution
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ How to build, run, and contribute to FerrisDB
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/rust-by-example/article-template.md
+++ b/docs/rust-by-example/article-template.md
@@ -19,7 +19,7 @@ Understanding [concept] through FerrisDB examples, compared with JavaScript, Pyt
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/rust-by-example/index.md
+++ b/docs/rust-by-example/index.md
@@ -14,7 +14,7 @@ Learn Rust through real database code - explained for CRUD developers
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/rust-by-example/ownership-memtable-sharing.md
+++ b/docs/rust-by-example/ownership-memtable-sharing.md
@@ -16,7 +16,7 @@ Understanding Rust ownership through FerrisDB's MemTable, compared with JavaScri
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 

--- a/docs/storage-engine.md
+++ b/docs/storage-engine.md
@@ -13,7 +13,7 @@ Detailed design and implementation of FerrisDB's custom LSM-tree storage engine
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes the table of contents (TOC) rendering issue across all documentation pages.

## Problem

The `{:toc}` directive was indented with spaces after "1. TOC" in multiple files:
```markdown
1. TOC
   {:toc}
```

Jekyll's kramdown processor requires `{:toc}` to be unindented for it to work properly. The indentation was preventing the table of contents from being generated on the documentation site.

## Solution

Removed the indentation from `{:toc}` in all affected files:
```markdown
1. TOC
{:toc}
```

## Changes

Fixed 19 documentation files:
- ✅ All deep-dive articles (6 files)
- ✅ All blog posts - both human and Claude's (6 files)
- ✅ Main documentation pages (4 files)
- ✅ Template files (3 files)

## Testing

- Verified the pattern was fixed in all files
- No other changes were made
- This should restore proper TOC generation on the Jekyll site

Co-Authored-By: Claude <noreply@anthropic.com>