### PR TITLE
docs: Add squash merge commentary guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Welcome! This is the quick reference for FerrisDB development. For detailed guidelines, see the [comprehensive documentation](docs/guidelines/README.md).
 
+⚠️ **Important**: This file is an INDEX for quick lookups. Do NOT add detailed content here - update the appropriate guideline file instead and link to it.
+
 ## 🚀 Quick Start
 
 ### Essential Reading
@@ -83,21 +85,13 @@ git push -u origin feature/your-feature
 gh pr create
 ```
 
-## 📝 Commit Commentary Requirements
+## 📝 Collaboration Commentary
 
-When committing changes, include a collaboration commentary:
+When working with Claude, include collaboration commentary in:
 
-```bash
-git commit -m "feat: Add feature description
-
-Detailed explanation of changes...
-
-🤖 Claude's Commentary:
-📊 Stats: X iterations, Y insights, Z refactors
-🔄 Process: Human noticed X → suggested Y → implemented Z
-💡 Key Learning: [Main insight that drove improvement]
-🎯 Outcome: [What was achieved]"
-```
+- **Commits**: See [Git Workflow - Claude's Collaboration Commentary](docs/guidelines/workflow/git-workflow.md#claudes-collaboration-commentary)
+- **PR Descriptions**: See [PR Process - Collaboration Summary](docs/guidelines/workflow/pr-process.md#pr-description-template)
+- **Squash Merges**: See [PR Process - Squash Merge Format](docs/guidelines/workflow/pr-process.md#squash-merge-commit-message-format)
 
 This helps track our collaboration patterns for blog posts and research.
 
@@ -138,9 +132,10 @@ This helps track our collaboration patterns for blog posts and research.
 ### When Updating Guidelines
 
 1. **Update the specific guideline file** in `docs/guidelines/`
-2. **Update this index** if adding new sections or changing structure
+2. **Update this index ONLY** if adding new sections or changing structure
 3. **Update cross-references** in related guideline files
 4. **Test all links** to ensure they work
+5. **NEVER add detailed content to CLAUDE.md** - it's an index, not a manual!
 
 ### My Quick Reminders
 

--- a/docs/guidelines/workflow/git-workflow.md
+++ b/docs/guidelines/workflow/git-workflow.md
@@ -439,6 +439,48 @@ chmod +x .git/hooks/pre-commit
 9. **Review your changes**: Use `git diff` before committing
 10. **Sign your commits**: Use GPG signing for important projects
 
+## Squash Merging with Commentary
+
+When squash merging PRs (especially those with Claude's collaboration):
+
+### Using GitHub CLI
+
+```bash
+# Squash merge with custom commit message
+gh pr merge <PR-number> --squash --body-file commit-message.txt
+
+# Or edit interactively
+gh pr merge <PR-number> --squash --edit
+```
+
+### Using GitHub Web UI
+
+1. Click "Squash and merge"
+2. Click "Edit commit message"
+3. Update the message to include:
+   - Clear summary of changes
+   - Collaboration commentary summary
+   - Co-authorship attribution
+
+### Why This Matters
+
+Including collaboration summaries in squash commits:
+
+- Preserves research data in git history
+- Makes patterns discoverable via `git log`
+- Documents the human-AI workflow evolution
+- Creates a permanent record of insights
+
+Example search for collaboration patterns:
+
+```bash
+# Find all commits with collaboration summaries
+git log --grep="🤖 Claude's Collaboration Summary" --oneline
+
+# See full collaboration details
+git log --grep="🤖" --pretty=full
+```
+
 ## Git Resources
 
 - [Pro Git Book](https://git-scm.com/book/en/v2)

--- a/docs/guidelines/workflow/pr-process.md
+++ b/docs/guidelines/workflow/pr-process.md
@@ -261,10 +261,66 @@ All PRs must pass these checks:
 ## Merging Guidelines
 
 1. **Squash merge** for feature branches to keep history clean
-2. **Merge commit** only for special cases (preserving commit history)
-3. **Never force push** to main branch
-4. **Delete branch** after merging (GitHub does this automatically)
-5. **Update related issues** after merge
+2. **Update squash commit message** to include:
+   - Summary of changes
+   - Collaboration commentary (if PR was created with Claude)
+3. **Merge commit** only for special cases (preserving commit history)
+4. **Never force push** to main branch
+5. **Delete branch** after merging (GitHub does this automatically)
+6. **Update related issues** after merge
+
+### Squash Merge Commit Message Format
+
+When squash merging a PR (especially those created with Claude), update the commit message to include both changes and collaboration summary:
+
+```
+<type>: <description> (#<PR-number>)
+
+<Summary of changes - can be copied from PR description>
+
+Changes:
+- Change 1
+- Change 2
+- Change 3
+
+🤖 Claude's Collaboration Summary:
+📊 Stats: X iterations, Y key insights, Z refactors
+🔍 Pattern: [Main collaboration pattern]
+💡 Key Learning: [Most impactful insight]
+🎯 Outcome: [What was achieved]
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+#### Example Squash Commit Message
+
+```
+docs: Implement collaboration commentary system and update blogging guidelines (#81)
+
+Major overhaul of blogging guidelines to ensure accuracy and implement
+collaboration tracking system.
+
+Changes:
+- Added collaboration commentary format for commits and PRs
+- Rewrote all blog posts to reflect actual events
+- Restructured blog system with unified _posts/ directory
+- Updated guidelines to emphasize verification
+- Fixed markdown formatting and linting issues
+
+🤖 Claude's Collaboration Summary:
+📊 Stats: 15+ iterations, 8 major insights, 4 complete rewrites
+🔍 Pattern: Deep Review → Accuracy Focus → Structural Improvement
+💡 Key Learning: Human's insistence on accuracy prevented fictional documentation
+🎯 Outcome: Accurate documentation with verifiable collaboration tracking
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+This format ensures that:
+
+- Git history contains collaboration insights
+- Patterns can be tracked over time without accessing PRs
+- Research data is preserved in the repository itself
 
 ## Review Checklist
 


### PR DESCRIPTION
## Summary

Added guidelines for including collaboration commentary in squash merge commit messages and clarified CLAUDE.md's role as an index.

## Changes Made

- **PR Process** (`docs/guidelines/workflow/pr-process.md`):
  - Added squash merge commit message format section
  - Included example showing how to preserve collaboration insights
  - Explained why this matters for research

- **Git Workflow** (`docs/guidelines/workflow/git-workflow.md`):
  - Added section on squash merging with commentary
  - Provided GitHub CLI and web UI instructions
  - Added examples for searching collaboration patterns in git history

- **CLAUDE.md**:
  - Simplified to reference guidelines instead of duplicating content
  - Added clear warnings that it's an index only
  - Updated maintenance notes to prevent future bloat

## Why This Matters

Including collaboration summaries in squash commits:
- Preserves research data directly in git history
- Makes patterns discoverable via `git log`
- Documents human-AI workflow evolution
- Creates permanent record of insights

## Testing

- ✅ All markdown files pass prettier and markdownlint
- ✅ Links to guideline sections verified
- ✅ Example commands tested

## 🤖 Claude's Collaboration Summary

**Stats:**
- 📊 3 files updated, 2 key insights from human feedback
- 🔄 Process: Human suggested tracking → implemented → human prevented bloat → clarified purpose
- 💡 Key Learning: Index files must remain indexes - documentation belongs in dedicated files
- 🎯 Outcome: Clean structure with git history serving as collaboration database

Co-Authored-By: Claude <noreply@anthropic.com>