### PR TITLE
fix: Remove collection-level permalink to resolve duplicate nav entry

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -86,7 +86,6 @@ back_to_top_text: "Back to top"
 collections:
   posts:
     output: true
-    permalink: /blog/:title/
 
 # Defaults
 defaults:


### PR DESCRIPTION
## Summary

This PR removes the collection-level permalink configuration that may be causing duplicate "Development Blog" entries in the navigation.

## Problem

The user noticed duplicate "Development Blog" entries in the navigation menu. Investigation revealed that the `_config.yml` had:

```yaml
collections:
  posts:
    output: true
    permalink: /blog/:title/
```

This collection-level permalink might cause Jekyll or the Just the Docs theme to automatically create a collection index at `/blog/`, conflicting with our manual `blog/index.html`.

## Solution

Remove the `permalink: /blog/:title/` line from the collections configuration. This is safe because:

1. **Each blog post already defines its own permalink** in the front matter (e.g., `/blog/human/day-1-from-just-use-rocksdb-to-building-from-scratch/`)
2. **No URLs will break** since we're not relying on the collection-level permalink
3. **Prevents potential conflicts** between automatic collection pages and our manual index

## Testing

- [x] Verified all blog posts have individual permalinks defined
- [x] Confirmed removal won't break any existing URLs
- [x] The duplicate nav entry should disappear after GitHub Pages rebuild

## Collaboration Summary

The human's keen observation about the collections configuration led to discovering that we had redundant permalink configuration. Since each post defines its own permalink, the collection-level setting was unnecessary and potentially problematic.

🤖 Generated with [Claude Code](https://claude.ai/code)