### PR TITLE
feat: Add blog perspective pages as navigation children

### DIFF
--- a/docs/blog/claude/index.html
+++ b/docs/blog/claude/index.html
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: "AI Perspective"
-nav_exclude: true
+parent: "Development Blog"
+nav_order: 2
 ---
 
 <div class="no_toc"></div>

--- a/docs/blog/human/index.html
+++ b/docs/blog/human/index.html
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: "Human Perspective"
-nav_exclude: true
+parent: "Development Blog"
+nav_order: 1
 ---
 
 <div class="no_toc"></div>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -2,6 +2,7 @@
 layout: default
 title: "Development Blog"
 nav_order: 7
+has_children: true
 ---
 
 <div class="no_toc"></div>


### PR DESCRIPTION
## Summary

This PR improves blog navigation by making the Human and AI perspective pages child items under Development Blog.

## Changes

- Added `has_children: true` to Development Blog
- Changed Human Perspective from `nav_exclude: true` to child of Development Blog with `nav_order: 1`
- Changed AI Perspective from `nav_exclude: true` to child of Development Blog with `nav_order: 2`

## Result

The navigation now shows a clear hierarchy:
```
Development Blog
├── Human Perspective
└── AI Perspective
```

## Benefits

1. **Better discoverability** - Readers immediately see there are two perspectives
2. **Clearer navigation** - Can expand Development Blog to jump directly to a specific perspective
3. **Improved UX** - The dual-perspective nature of the blog is now obvious
4. **Consistent hierarchy** - Similar to how Database Concepts and Rust by Example have child pages

## Collaboration Summary

The human suggested making the perspective pages child navigation items. This simple change significantly improves the blog's usability by making its unique dual-perspective structure immediately visible in the navigation.

🤖 Generated with [Claude Code](https://claude.ai/code)