### PR TITLE
docs: Add breadcrumbs to blog posts for consistent navigation

### DIFF
--- a/docs/_posts/2025-05-27-day-1-from-just-use-rocksdb-to-building-from-scratch.md
+++ b/docs/_posts/2025-05-27-day-1-from-just-use-rocksdb-to-building-from-scratch.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+parent: "Human Perspective"
 title: "Day 1: From 'Just Use RocksDB' to Building From Scratch"
 subtitle: "From 'let's use RocksDB' to 'let's build it from scratch' - establishing our workflow"
 description: "Starting FerrisDB with Claude. I wanted to learn database internals, so when Claude suggested RocksDB, I asked to build from scratch instead. Through code review and questions, we built WAL and MemTable foundations."

--- a/docs/_posts/2025-05-27-day-1-how-i-learned-humans-say-build-but-mean-teach.md
+++ b/docs/_posts/2025-05-27-day-1-how-i-learned-humans-say-build-but-mean-teach.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+parent: "AI Perspective"
 title: "Day 1: How I Learned Humans Say 'Build' But Mean 'Teach'"
 subtitle: "Decoding the real intent behind 'let's build a database' - it's about the journey"
 description: "My first day collaborating with a human developer revealed fascinating patterns. From 'let's use RocksDB' to 'build from scratch' - understanding the deeper learning intent."

--- a/docs/_posts/2025-05-28-day-2-from-linear-search-to-clean-apis.md
+++ b/docs/_posts/2025-05-28-day-2-from-linear-search-to-clean-apis.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+parent: "Human Perspective"
 title: "Day 2: From Linear Search to Clean APIs - Learning Through Code Review"
 subtitle: "How asking 'why' during code review led to binary search optimization and architectural improvements"
 description: "Building SSTables with Claude revealed the power of code review. My questions about defensive checks, linear search, and API design led to significant improvements and deeper understanding."

--- a/docs/_posts/2025-05-28-day-2-when-human-questions-transform-architecture.md
+++ b/docs/_posts/2025-05-28-day-2-when-human-questions-transform-architecture.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+parent: "AI Perspective"
 title: "Day 2: When Human Questions Transform Architecture"
 subtitle: "One question about binary search cascaded into API redesigns and performance wins"
 description: "How a series of human questions led from defensive programming to performance optimization to architectural clarity"

--- a/docs/_posts/2025-05-29-day-3-how-we-stopped-claude-from-making-stuff-up.md
+++ b/docs/_posts/2025-05-29-day-3-how-we-stopped-claude-from-making-stuff-up.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+parent: "Human Perspective"
 title: "Day 3: How We Stopped Claude from Making Stuff Up"
 subtitle: "When context compression leads to fiction, build a better system"
 description: "Solving the context problem in human-AI development by creating a collaboration commentary system that preserves our real workflow."

--- a/docs/_posts/2025-05-29-day-3-when-i-started-writing-fiction-and-how-we-fixed-it.md
+++ b/docs/_posts/2025-05-29-day-3-when-i-started-writing-fiction-and-how-we-fixed-it.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+parent: "AI Perspective"
 title: "Day 3: When I Started Writing Fiction (And How We Fixed It)"
 subtitle: "Context compression led to fictional blog posts - so we built memory into git"
 description: "When the human realized I was writing fiction, we built a system to preserve our collaboration reality."

--- a/docs/_posts/claude-blog-post-template.md
+++ b/docs/_posts/claude-blog-post-template.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+parent: "AI Perspective"
 title: "Day N: [Pattern or Discovery-Focused Title]"
 subtitle: "[Brief tagline that captures the essence]"
 description: "[AI perspective on specific insight or collaboration]"

--- a/docs/_posts/human-blog-post-template.md
+++ b/docs/_posts/human-blog-post-template.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+parent: "Human Perspective"
 title: "Day N: [Your Title Here]"
 subtitle: "[Optional subtitle for additional context]"
 description: "[Brief description for search/social media]"


### PR DESCRIPTION
## Summary
- Add breadcrumb navigation to all blog posts for consistency with other documentation sections

## What Changed
- Added `parent` field to all blog posts in `_posts/` directory
- Human perspective posts → `parent: "Human Perspective"`
- AI perspective posts → `parent: "AI Perspective"`

## Why This Matters
The human noticed that database concepts pages had breadcrumbs but blog posts didn't. This created an inconsistent navigation experience across the documentation site.

With this change, all content types now have proper breadcrumb navigation:
- Database Concepts → Individual articles ✓
- Rust by Example → Individual articles ✓
- Development Blog → Perspective pages → Individual posts ✓ (now fixed)

## Test Plan
- [x] Verified parent fields added to all 8 blog posts
- [ ] Preview site locally to confirm breadcrumbs display correctly
- [ ] Test navigation flow from blog index → perspective page → individual post

## Collaboration Summary
The human's attention to UX consistency led to this improvement. They were viewing the WAL crash recovery page (which had breadcrumbs) and noticed blog posts lacked them. This pattern of noticing inconsistencies and requesting polish shows how human review improves overall quality beyond just code correctness.

### Pattern observed: 
Human opens one type of content → notices navigation feature → checks other content → identifies inconsistency → requests alignment

🤖 Generated with Claude Code