### PR TITLE
fix: Remove redundant security issue link from issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -12,6 +12,3 @@ contact_links:
   - name: 📚 Tutorials
     url: https://ferrisdb.org/tutorials
     about: Learn by building with our step-by-step tutorials
-  - name: 🔒 Security Issues
-    url: https://github.com/ferrisdb/ferrisdb/blob/main/SECURITY.md
-    about: For security vulnerabilities, please see our security policy


### PR DESCRIPTION
## Summary

This PR removes the redundant "Security Issues" link from the issue template configuration.

## Rationale

GitHub already provides a built-in "Report a security vulnerability" option when creating new issues (if security features are enabled for the repository). This built-in feature is superior because it:

- Keeps security vulnerabilities private until they're fixed
- Follows security best practices
- Integrates with GitHub's security advisories system
- Provides a proper workflow for responsible disclosure

Having our own link to SECURITY.md is redundant and could confuse users about which option to use for reporting security issues.

## Changes

- Removed the "🔒 Security Issues" link from `.github/ISSUE_TEMPLATE/config.yml`

## Testing

The issue template configuration continues to work properly with the remaining links.

🤖 Generated with [Claude Code](https://claude.ai/code)