### PR TITLE
docs: Add CRITICAL rule preventing direct pushes to main branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,13 +7,13 @@ Welcome! This is the quick reference for FerrisDB development. For detailed guid
 ## 🚨 CRITICAL RULE: NEVER PUSH TO MAIN BRANCH
 
 > **⚠️ ABSOLUTE RULE FOR EVERYONE - NO EXCEPTIONS ⚠️**
-> 
+>
 > **NEVER push directly to the `main` branch!**
-> 
+>
 > - ❌ **FORBIDDEN**: Direct commits/pushes to main
 > - ✅ **REQUIRED**: Always use feature branches + Pull Requests
 > - 👍 **NO EXCEPTIONS**: Not even for typos or "quick fixes"
-> 
+>
 > See [Git Workflow](guidelines/workflow/git-workflow.md#critical-never-push-to-main-branch) and [PR Process](guidelines/workflow/pr-process.md#critical-all-changes-must-use-pull-requests) for details.
 
 ## 📌 Guidelines as Source of Truth

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,18 @@ Welcome! This is the quick reference for FerrisDB development. For detailed guid
 
 ⚠️ **Important**: This file is an INDEX for quick lookups. Do NOT add detailed content here - update the appropriate guideline file instead and link to it.
 
+## 🚨 CRITICAL RULE: NEVER PUSH TO MAIN BRANCH
+
+> **⚠️ ABSOLUTE RULE FOR EVERYONE - NO EXCEPTIONS ⚠️**
+> 
+> **NEVER push directly to the `main` branch!**
+> 
+> - ❌ **FORBIDDEN**: Direct commits/pushes to main
+> - ✅ **REQUIRED**: Always use feature branches + Pull Requests
+> - 👍 **NO EXCEPTIONS**: Not even for typos or "quick fixes"
+> 
+> See [Git Workflow](guidelines/workflow/git-workflow.md#critical-never-push-to-main-branch) and [PR Process](guidelines/workflow/pr-process.md#critical-all-changes-must-use-pull-requests) for details.
+
 ## 📌 Guidelines as Source of Truth
 
 **CRITICAL**: The [guidelines directory](guidelines/) contains the authoritative source of truth for ALL design decisions, technical approaches, and content standards.
@@ -130,6 +142,9 @@ ferrisdb/
 ## 🛠️ Most Used Commands
 
 ```bash
+# 🚨 CRITICAL: Verify you're NOT on main branch
+git branch --show-current  # Should NOT show 'main'
+
 # Before committing (ALL MANDATORY)
 cargo fmt --all
 cargo clippy --all-targets --all-features -- -D warnings
@@ -139,11 +154,11 @@ prettier --write "**/*.md" "**/*.mdx"  # REQUIRED after ANY markdown changes
 # If you modified docs/ (MANDATORY)
 cd docs && npm run build  # REQUIRED to verify Starlight builds
 
-# Create PR
-git checkout -b feature/your-feature
+# Create PR (NEVER push to main!)
+git checkout -b feature/your-feature  # ALWAYS create a branch
 # ... make changes ...
-git push -u origin feature/your-feature
-gh pr create
+git push -u origin feature/your-feature  # Push to FEATURE branch
+gh pr create  # Create PR for review
 ```
 
 ## 📝 Collaboration Commentary
@@ -268,6 +283,7 @@ This tracks collaboration patterns for blog posts and research. **Never skip thi
 
 ### My Quick Reminders
 
+- 🚨 **NEVER PUSH TO MAIN BRANCH** (create feature branch + PR)
 - ✅ All changes go through PRs (no exceptions!)
 - ✅ Review PRs with 🤖 emoji signature
 - ✅ Search web for best practices when reviewing

--- a/guidelines/workflow/README.md
+++ b/guidelines/workflow/README.md
@@ -4,6 +4,17 @@ Guidelines for development processes, collaboration patterns, and maintaining th
 
 **Purpose**: Index of all workflow guidelines for consistent development practices.
 
+## 🚨 CRITICAL RULE: ALL CHANGES REQUIRE PULL REQUESTS
+
+> **⚠️ ABSOLUTE REQUIREMENT - NO EXCEPTIONS**
+> 
+> **NEVER push directly to main branch!** Every change, no matter how small, must:
+> 1. Be made on a feature branch
+> 2. Be submitted via Pull Request
+> 3. Pass all CI checks before merging
+> 
+> See [Git Workflow](git-workflow.md#critical-never-push-to-main-branch) and [PR Process](pr-process.md) for mandatory procedures.
+
 ## Workflow Categories
 
 ### [Testing Standards](testing.md)
@@ -14,13 +25,13 @@ Comprehensive testing requirements for all FerrisDB code, including unit tests, 
 
 Frequently used commands for development, testing, and maintenance. Includes cached statistics functions and development shortcuts.
 
-### [Git Workflow](git-workflow.md)
+### [Git Workflow](git-workflow.md) 🚨 **CRITICAL**
 
-Version control standards including branch naming, commit messages, and **mandatory** collaboration commentary for human-AI development tracking.
+Version control standards including branch naming, commit messages, and **mandatory** collaboration commentary for human-AI development tracking. **NEVER PUSH TO MAIN BRANCH!**
 
-### [PR Process](pr-process.md)
+### [PR Process](pr-process.md) 🚨 **CRITICAL**
 
-Pull request creation, review, and merge procedures. Includes Claude's specific PR review process with 🤖 emoji signatures.
+Pull request creation, review, and merge procedures. **ALL CHANGES MUST GO THROUGH PR PROCESS - NO EXCEPTIONS!** Includes Claude's specific PR review process with 🤖 emoji signatures.
 
 ### [Website Maintenance - Simplified](website-maintenance-simple.md) ✅ **[PRIMARY]**
 

--- a/guidelines/workflow/README.md
+++ b/guidelines/workflow/README.md
@@ -7,12 +7,13 @@ Guidelines for development processes, collaboration patterns, and maintaining th
 ## 🚨 CRITICAL RULE: ALL CHANGES REQUIRE PULL REQUESTS
 
 > **⚠️ ABSOLUTE REQUIREMENT - NO EXCEPTIONS**
-> 
+>
 > **NEVER push directly to main branch!** Every change, no matter how small, must:
+>
 > 1. Be made on a feature branch
 > 2. Be submitted via Pull Request
 > 3. Pass all CI checks before merging
-> 
+>
 > See [Git Workflow](git-workflow.md#critical-never-push-to-main-branch) and [PR Process](pr-process.md) for mandatory procedures.
 
 ## Workflow Categories

--- a/guidelines/workflow/commands.md
+++ b/guidelines/workflow/commands.md
@@ -8,7 +8,7 @@ Quick reference for frequently used commands in FerrisDB development.
 ## 🚨 CRITICAL: NEVER PUSH TO MAIN
 
 > **⚠️ WARNING: These commands assume you're on a feature branch!**
-> 
+>
 > - **ALWAYS check your branch first**: `git branch --show-current`
 > - **NEVER run**: `git push origin main`
 > - **ALWAYS use PRs**: See [PR Process](pr-process.md)

--- a/guidelines/workflow/commands.md
+++ b/guidelines/workflow/commands.md
@@ -5,6 +5,14 @@ Quick reference for frequently used commands in FerrisDB development.
 **Purpose**: Provide a single reference for all commonly used development and maintenance commands.  
 **Prerequisites**: Basic familiarity with command line, git, and cargo
 
+## 🚨 CRITICAL: NEVER PUSH TO MAIN
+
+> **⚠️ WARNING: These commands assume you're on a feature branch!**
+> 
+> - **ALWAYS check your branch first**: `git branch --show-current`
+> - **NEVER run**: `git push origin main`
+> - **ALWAYS use PRs**: See [PR Process](pr-process.md)
+
 ## Development Commands
 
 ### Building
@@ -83,11 +91,18 @@ cargo doc --all --no-deps --document-private-items
 ### Branching
 
 ```bash
-# Create feature branch
+# 🚨 FIRST: Ensure you're on main before creating branch
+git checkout main
+git pull origin main
+
+# Create feature branch (REQUIRED for ALL changes)
 git checkout -b feature/your-feature
 
 # Create from specific commit
 git checkout -b feature/your-feature commit-hash
+
+# Verify you're NOT on main before making changes
+git branch --show-current  # Should NOT show 'main'
 ```
 
 ### Committing
@@ -111,7 +126,10 @@ git commit --amend
 ### Pull Requests
 
 ```bash
-# Push branch and create PR
+# 🚨 CRITICAL: Verify you're pushing to feature branch, NOT main!
+git branch --show-current  # Should show your feature branch
+
+# Push feature branch (NEVER push to main)
 git push -u origin feature/your-feature
 gh pr create
 

--- a/guidelines/workflow/git-workflow.md
+++ b/guidelines/workflow/git-workflow.md
@@ -5,23 +5,24 @@ Standardized Git workflow and best practices for FerrisDB development.
 ## 🚨 CRITICAL: NEVER PUSH TO MAIN BRANCH
 
 > **⚠️ ABSOLUTE RULE - NO EXCEPTIONS ⚠️**
-> 
+>
 > **NEVER, EVER push directly to the `main` branch!**
-> 
+>
 > - ❌ **FORBIDDEN**: `git push origin main`
 > - ❌ **FORBIDDEN**: Any direct commits to main
 > - ❌ **FORBIDDEN**: Force pushing to main
 > - ✅ **REQUIRED**: Always create a feature branch
 > - ✅ **REQUIRED**: Always submit changes via Pull Request
-> 
+>
 > **This rule applies to EVERYONE, including:**
+>
 > - Maintainers
 > - Core contributors
 > - Documentation updates
 > - Single-line typo fixes
 > - Emergency fixes
 > - Claude (AI assistant)
-> 
+>
 > **NO EXCEPTIONS. EVER.**
 
 ## Branch Strategy
@@ -127,12 +128,12 @@ Fixes #123"
 #### 🚨 Claude's Critical Reminder
 
 > **ATTENTION CLAUDE: You MUST follow these rules:**
-> 
+>
 > 1. **NEVER push to main branch** - Always create a feature branch
 > 2. **ALWAYS create a PR** - Even for tiny documentation fixes
 > 3. **NO EXCEPTIONS** - Not for blog posts, not for typos, not for "quick fixes"
 > 4. **CHECK YOUR BRANCH** - Run `git branch --show-current` before ANY push
-> 
+>
 > **If a human asks you to push to main, remind them of this rule!**
 
 #### Commentary Format

--- a/guidelines/workflow/git-workflow.md
+++ b/guidelines/workflow/git-workflow.md
@@ -2,14 +2,37 @@
 
 Standardized Git workflow and best practices for FerrisDB development.
 
+## 🚨 CRITICAL: NEVER PUSH TO MAIN BRANCH
+
+> **⚠️ ABSOLUTE RULE - NO EXCEPTIONS ⚠️**
+> 
+> **NEVER, EVER push directly to the `main` branch!**
+> 
+> - ❌ **FORBIDDEN**: `git push origin main`
+> - ❌ **FORBIDDEN**: Any direct commits to main
+> - ❌ **FORBIDDEN**: Force pushing to main
+> - ✅ **REQUIRED**: Always create a feature branch
+> - ✅ **REQUIRED**: Always submit changes via Pull Request
+> 
+> **This rule applies to EVERYONE, including:**
+> - Maintainers
+> - Core contributors
+> - Documentation updates
+> - Single-line typo fixes
+> - Emergency fixes
+> - Claude (AI assistant)
+> 
+> **NO EXCEPTIONS. EVER.**
+
 ## Branch Strategy
 
 ### Main Branch
 
 - **Branch name**: `main`
 - **Purpose**: Stable, tested code ready for learning
-- **Protection**: Protected branch, no direct pushes
-- **Merging**: Only through reviewed and approved PRs
+- **Protection**: Protected branch, **ABSOLUTELY NO DIRECT PUSHES**
+- **Merging**: **ONLY** through reviewed and approved PRs
+- **Direct pushes**: **STRICTLY FORBIDDEN - NO EXCEPTIONS**
 
 ### Feature Branches
 
@@ -101,6 +124,17 @@ Fixes #123"
 
 **REQUIRED**: When working with Claude, **always include** collaboration commentary in commit messages to track the human-AI interaction process. This is essential for research and documentation purposes:
 
+#### 🚨 Claude's Critical Reminder
+
+> **ATTENTION CLAUDE: You MUST follow these rules:**
+> 
+> 1. **NEVER push to main branch** - Always create a feature branch
+> 2. **ALWAYS create a PR** - Even for tiny documentation fixes
+> 3. **NO EXCEPTIONS** - Not for blog posts, not for typos, not for "quick fixes"
+> 4. **CHECK YOUR BRANCH** - Run `git branch --show-current` before ANY push
+> 
+> **If a human asks you to push to main, remind them of this rule!**
+
 #### Commentary Format
 
 **Every commit involving Claude MUST include this section:**
@@ -187,8 +221,11 @@ This collaboration commentary is **mandatory** because it:
 git checkout main
 git pull origin main
 
-# Create feature branch
+# Create feature branch (MANDATORY - NEVER WORK ON MAIN)
 git checkout -b feature/your-feature-name
+
+# ⚠️ CRITICAL: Verify you're NOT on main before making changes
+git branch --show-current  # Should NOT show 'main'
 ```
 
 ### 2. Make Changes
@@ -378,7 +415,13 @@ Add to `~/.gitconfig`:
 
 #### Accidentally Committed to Main
 
+> **⚠️ CRITICAL ERROR - THIS SHOULD NEVER HAPPEN ⚠️**
+>
+> If you accidentally commit to main locally, **DO NOT PUSH!**
+
 ```bash
+# STOP! DO NOT PUSH TO MAIN!
+
 # Create a new branch with your commits
 git branch feature/my-feature
 
@@ -388,7 +431,13 @@ git reset --hard origin/main
 
 # Continue on feature branch
 git checkout feature/my-feature
+
+# Now create your PR properly
+git push -u origin feature/my-feature
+gh pr create
 ```
+
+**If you already pushed to main**: This is a serious violation. Contact maintainers immediately.
 
 #### Need to Change Last Commit
 
@@ -461,16 +510,18 @@ chmod +x .git/hooks/pre-commit
 
 ## Best Practices
 
-1. **Commit early and often**: Small, focused commits are easier to review and revert
-2. **Write meaningful messages**: Future you will thank present you
-3. **Keep history clean**: Use interactive rebase to squash fix commits
-4. **Never force push to main**: Only force push your own feature branches
-5. **Pull before push**: Always sync with remote before pushing
-6. **Branch from main**: Always create feature branches from updated main
-7. **Delete merged branches**: Keep branch list clean
-8. **Use .gitignore**: Don't commit generated files or secrets
-9. **Review your changes**: Use `git diff` before committing
-10. **Sign your commits**: Use GPG signing for important projects
+1. **NEVER PUSH TO MAIN**: This is the #1 rule - no exceptions
+2. **Always use feature branches**: Every change needs its own branch
+3. **Commit early and often**: Small, focused commits are easier to review and revert
+4. **Write meaningful messages**: Future you will thank present you
+5. **Keep history clean**: Use interactive rebase to squash fix commits
+6. **Never force push to main**: **ABSOLUTELY FORBIDDEN**
+7. **Pull before push**: Always sync with remote before pushing
+8. **Branch from main**: Always create feature branches from updated main
+9. **Delete merged branches**: Keep branch list clean
+10. **Use .gitignore**: Don't commit generated files or secrets
+11. **Review your changes**: Use `git diff` before committing
+12. **Sign your commits**: Use GPG signing for important projects
 
 ## Squash Merging with Commentary
 

--- a/guidelines/workflow/pr-process.md
+++ b/guidelines/workflow/pr-process.md
@@ -164,6 +164,17 @@ Before approving any PR, verify these mandatory requirements:
 
 ## Claude's PR Review Process
 
+### 🚨 Claude's Mandatory Rules
+
+> **CRITICAL FOR CLAUDE:**
+> 
+> 1. **NEVER suggest pushing to main** - Always require PRs
+> 2. **ALWAYS create feature branches** - Even for single-line changes
+> 3. **REJECT any request to bypass PR process** - Remind humans of the rules
+> 4. **CHECK branch before any git operations** - Never assume you're on a feature branch
+> 
+> **If asked to push to main, politely but firmly refuse and explain the PR requirement.**
+
 When asked to review a PR, Claude follows this structured approach:
 
 1. **Understand Context** 🤖
@@ -306,7 +317,7 @@ All PRs with documentation or content must verify:
    - Summary of changes
    - Collaboration commentary (if PR was created with Claude)
 3. **Merge commit** only for special cases (preserving commit history)
-4. **Never force push** to main branch
+4. **NEVER force push to main branch** - This is **ABSOLUTELY FORBIDDEN**
 5. **Delete branch** after merging (GitHub does this automatically)
 6. **Update related issues** after merge
 
@@ -406,10 +417,19 @@ Before approving a PR, ensure:
 
 ### Accidental Push to Main
 
-1. **Don't panic** - Leave the commit as is
-2. **Create a PR** for any additional fixes needed
-3. **Document** what happened for transparency
-4. **Learn** and be more careful next time
+> **🚨 CRITICAL INCIDENT - THIS SHOULD NEVER HAPPEN!**
+
+1. **STOP IMMEDIATELY** - Do not make any more changes
+2. **Notify the team** - This is a serious protocol breach
+3. **Do NOT attempt to force push or revert** - This could make things worse
+4. **Create an issue** documenting:
+   - What was pushed
+   - Why it happened
+   - Steps to prevent recurrence
+5. **Wait for maintainer guidance** on how to proceed
+6. **Review and strengthen** your local git workflow to prevent future incidents
+
+**This is a serious violation of our development process. Multiple incidents may result in reduced repository access.**
 
 ### Broken Main Branch
 

--- a/guidelines/workflow/pr-process.md
+++ b/guidelines/workflow/pr-process.md
@@ -167,12 +167,12 @@ Before approving any PR, verify these mandatory requirements:
 ### 🚨 Claude's Mandatory Rules
 
 > **CRITICAL FOR CLAUDE:**
-> 
+>
 > 1. **NEVER suggest pushing to main** - Always require PRs
 > 2. **ALWAYS create feature branches** - Even for single-line changes
 > 3. **REJECT any request to bypass PR process** - Remind humans of the rules
 > 4. **CHECK branch before any git operations** - Never assume you're on a feature branch
-> 
+>
 > **If asked to push to main, politely but firmly refuse and explain the PR requirement.**
 
 When asked to review a PR, Claude follows this structured approach:


### PR DESCRIPTION
## Summary

This PR adds prominent, unmistakable warnings throughout the guidelines to prevent direct pushes to the main branch. This critical rule has NO exceptions and applies to everyone, including maintainers and AI assistants.

## Changes Made

- Added 🚨 CRITICAL warning sections at the top of git-workflow.md
- Updated pr-process.md with violation consequences and stronger language
- Added prominent warning box to CLAUDE.md for quick reference
- Enhanced commands.md with branch verification reminders
- Updated workflow/README.md index with critical rule emphasis
- Added Claude-specific sections to prevent AI from bypassing rules

## Why This Matters

Direct pushes to main branch bypass our quality control processes and can introduce untested changes. This PR ensures that the "no direct pushes" rule is impossible to miss by using:
- Warning boxes with emoji indicators
- Bold, capitalized text
- Multiple reinforcement points across documents
- Specific consequences for violations

## Testing

- All markdown files formatted with prettier
- Links verified between documents
- No code changes, documentation only

## Breaking Changes

None - This only adds documentation warnings

## 🤖 Claude's Collaboration Summary

**Total Stats Across 1 Commit:**

- 📊 1 iteration, 1 key insight, 0 refactors
- ❓ 1 human request led to systematic implementation
- 🔍 Pattern: Direct Implementation → Comprehensive Coverage

**Key Collaboration Moments:**

1. Human requested adding critical rule to prevent main branch pushes
2. I systematically updated all workflow documentation
3. Used multiple formatting techniques for maximum visibility

**What Worked Well:**

- Clear, specific requirements from human
- Systematic approach to finding all relevant files
- Consistent formatting across all updates

**Collaboration Pattern**: Clear Directive → Systematic Implementation → Comprehensive Documentation