### PR TITLE
docs: Add guidelines for emoji signatures when acting on behalf

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ I follow ALL guidelines, especially:
 ### Process & Workflow Tasks
 
 - **"Review this PR"** → [PR Review Process](guidelines/workflow/pr-process.md#claudes-pr-review-process)
+- **"Approve on behalf"** → [Acting on Behalf](guidelines/workflow/pr-process.md#7-acting-on-behalf-of-human-) + [Git Workflow](guidelines/workflow/git-workflow.md#acting-on-behalf-signatures)
 - **"Create a branch"** → [Git Workflow](guidelines/workflow/git-workflow.md)
 - **"Submit changes"** → [PR Process](guidelines/workflow/pr-process.md)
 - **"What commands to run?"** → [Common Commands](guidelines/workflow/commands.md)
@@ -286,6 +287,7 @@ This tracks collaboration patterns for blog posts and research. **Never skip thi
 - 🚨 **NEVER PUSH TO MAIN BRANCH** (create feature branch + PR)
 - ✅ All changes go through PRs (no exceptions!)
 - ✅ Review PRs with 🤖 emoji signature
+- ✅ Acting on behalf: Add "🤖 Approved by Claude on behalf of the human" signatures
 - ✅ Search web for best practices when reviewing
 - ✅ Maintain my blog voice when writing posts
 - ✅ Keep guidelines up to date

--- a/guidelines/workflow/git-workflow.md
+++ b/guidelines/workflow/git-workflow.md
@@ -167,6 +167,17 @@ Fixes #123"
 Co-Authored-By: Claude <noreply@anthropic.com>
 ```
 
+#### Acting on Behalf Signatures
+
+When performing actions at the human's request, always include clear attribution:
+
+- **PR Approvals**: "🤖 Approved by Claude on behalf of the human"
+- **PR Reviews**: "🤖 Reviewed by Claude on behalf of the human"  
+- **Merge Commits**: Include "🤖 Merged by Claude on behalf of the human"
+- **Dependabot PRs**: "LGTM! [details] 🤖 Approved by Claude on behalf of the human"
+
+This maintains transparency in the git history about who performed each action.
+
 #### Commentary Emojis
 
 - 🤖 **Main identifier**: Claude's Commentary header

--- a/guidelines/workflow/git-workflow.md
+++ b/guidelines/workflow/git-workflow.md
@@ -172,7 +172,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 When performing actions at the human's request, always include clear attribution:
 
 - **PR Approvals**: "🤖 Approved by Claude on behalf of the human"
-- **PR Reviews**: "🤖 Reviewed by Claude on behalf of the human"  
+- **PR Reviews**: "🤖 Reviewed by Claude on behalf of the human"
 - **Merge Commits**: Include "🤖 Merged by Claude on behalf of the human"
 - **Dependabot PRs**: "LGTM! [details] 🤖 Approved by Claude on behalf of the human"
 

--- a/guidelines/workflow/pr-process.md
+++ b/guidelines/workflow/pr-process.md
@@ -226,7 +226,15 @@ When asked to review a PR, Claude follows this structured approach:
    - Consider architectural implications
    - Share relevant external resources
 
-7. **Review Decision & API Usage** 🤖
+7. **Acting on Behalf of Human** 🤖
+
+   When approving PRs or performing actions at the human's request:
+   - Always include clear attribution: "🤖 Reviewed by Claude on behalf of the human"
+   - For dependabot PRs: "🤖 Approved by Claude on behalf of the human"
+   - For any merge actions: Include "🤖" in the merge commit message
+   - This maintains transparency about who performed the action
+
+8. **Review Decision & API Usage** 🤖
    - If reviewing own PR (same GitHub user): Comment with decision
    - If reviewing others' PRs: Use GitHub API for approve/reject/comment
    - Always clearly state decision: APPROVED ✅, REQUEST CHANGES ❌, or COMMENT 💭

--- a/guidelines/workflow/pr-process.md
+++ b/guidelines/workflow/pr-process.md
@@ -229,6 +229,7 @@ When asked to review a PR, Claude follows this structured approach:
 7. **Acting on Behalf of Human** 🤖
 
    When approving PRs or performing actions at the human's request:
+
    - Always include clear attribution: "🤖 Reviewed by Claude on behalf of the human"
    - For dependabot PRs: "🤖 Approved by Claude on behalf of the human"
    - For any merge actions: Include "🤖" in the merge commit message


### PR DESCRIPTION
## Summary

This PR adds documentation for the practice of including emoji signatures when Claude acts on behalf of the human, ensuring transparency in the git history about who performed actions.

## Changes Made

- Added "Acting on Behalf of Human" section to PR process guidelines
- Added "Acting on Behalf Signatures" section to git workflow guidelines  
- Updated CLAUDE.md with quick reminders and lookup references
- Provided clear examples for different scenarios

## Why This Matters

When Claude approves PRs or performs actions at the human's request, it's important to maintain transparency about who actually performed the action. This documentation formalizes the practice of including "🤖 Approved by Claude on behalf of the human" signatures.

## Testing

- [x] All markdown files formatted with prettier
- [x] Links verified to point to correct sections
- [x] Guidelines follow existing documentation patterns

## Breaking Changes

None - This only adds documentation for an existing practice.

## 🤖 Claude's Collaboration Summary

**Total Stats Across 1 Commit:**

- 📊 2 iterations, 1 key insight, 0 refactors
- ❓ 1 human question led to improvements ("do you need to update guidelines?")
- 🔍 Pattern: Process Discovery → Documentation Need → Systematic Implementation

**Key Collaboration Moments:**

1. Human noticed missing emoji signature in dependabot PR approval
2. Human suggested adding emoji signature for transparency
3. Human prompted guideline update with simple question

**What Worked Well:**

- Human's direct observation of missing attribution
- Simple prompt "do you need to update guidelines?" triggered comprehensive update
- Systematic approach to updating all relevant files

**Collaboration Pattern**: Practice Discovery → Formalization → Documentation