### PR TITLE
feat: Add Google Analytics to Starlight website

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -35,6 +35,25 @@ export default defineConfig({
 						defer: true,
 					},
 				},
+				// Google Analytics
+				{
+					tag: 'script',
+					attrs: {
+						src: 'https://www.googletagmanager.com/gtag/js?id=G-JPW5LY247F',
+						async: true,
+					},
+				},
+				{
+					tag: 'script',
+					content: `
+						window.dataLayer = window.dataLayer || [];
+						function gtag(){dataLayer.push(arguments);}
+						gtag('js', new Date());
+						gtag('config', 'G-JPW5LY247F', {
+							anonymize_ip: true // GDPR compliance
+						});
+					`,
+				},
 			],
 			sidebar: [
 				{


### PR DESCRIPTION
## Summary

This PR adds Google Analytics tracking to the FerrisDB documentation website as specified in the website design guidelines.

## Changes Made

- Added Google Analytics script tags to `astro.config.mjs` head section
- Used tracking ID `G-JPW5LY247F` from guidelines
- Enabled `anonymize_ip` for GDPR compliance
- Verified build still works correctly

## Why This Matters

Analytics tracking helps us understand:
- Which documentation pages are most useful to developers
- Tutorial completion rates
- Developer engagement patterns
- Areas that need improvement

## Testing

- [x] Website builds successfully with `npm run build`
- [x] No TypeScript or build errors
- [x] Analytics configuration matches guidelines exactly
- [x] GDPR compliance maintained with IP anonymization

## Breaking Changes

None - This only adds analytics tracking without affecting functionality.

## Implementation Details

Added two script tags to the Starlight head configuration:
1. Google Tag Manager loader script (async)
2. Initialization script with tracking ID and GDPR settings

The implementation follows the exact pattern documented in `/guidelines/content/website-design-starlight.md` (lines 489-521).

## 🤖 Claude's Collaboration Summary

**Total Stats Across 1 Commit:**

- 📊 1 iteration, 1 key insight, 0 refactors
- ❓ 0 human questions (direct implementation request)
- 🔍 Pattern: Guideline Reference → Implementation → Verification

**Key Collaboration Moments:**

1. Human requested Google Analytics "as per the guideline"
2. Found exact implementation details in website design guidelines
3. Implemented precisely as documented with GDPR compliance

**What Worked Well:**

- Clear guidelines made implementation straightforward
- Build verification ensured no breaking changes
- Following documented patterns maintained consistency

**Collaboration Pattern**: Guideline-Driven Implementation