### PR TITLE
fix: Update landing page to reference FoundationDB instead of PostgreSQL

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -24,8 +24,8 @@ import { Card, CardGrid, Tabs, TabItem, Aside, Badge } from "@astrojs/starlight/
 import Stats from "../../components/Stats.astro";
 
 <Aside type="tip" title="Not Another Database">
-  We're not building a database to compete with PostgreSQL. We're documenting the journey of
-  learning how PostgreSQL works by building our own. If you need a database, use PostgreSQL. If you
+  We're not building a database to compete with FoundationDB. We're documenting the journey of
+  learning how FoundationDB works by building our own. If you need a database, use FoundationDB. If you
   want to understand databases, join us!
 </Aside>
 


### PR DESCRIPTION
Fixes #126

Updated the "Not Another Database" section on the landing page to correctly reference FoundationDB instead of PostgreSQL, as the project is inspired by FoundationDB's architecture.

**Changes:**
- Updated text in `docs/src/content/docs/index.mdx` lines 27-28
- Maintained the same message structure and intent

Generated with [Claude Code](https://claude.ai/code)