### PR TITLE
feat: Reduce WAL key/value size limits for better performance

### DIFF
--- a/ferrisdb-storage/src/wal/log_entry.rs
+++ b/ferrisdb-storage/src/wal/log_entry.rs
@@ -12,8 +12,8 @@ const HEADER_SIZE: usize = 8; // length + checksum
 const MIN_ENTRY_SIZE: usize = HEADER_SIZE + 8 + 1 + 4 + 4; // header + timestamp + op + key_len + val_len
 
 // Size limits for DoS protection
-const MAX_KEY_SIZE: usize = 1024 * 1024; // 1MB
-const MAX_VALUE_SIZE: usize = 10 * 1024 * 1024; // 10MB
+const MAX_KEY_SIZE: usize = 10 * 1024; // 10KB
+const MAX_VALUE_SIZE: usize = 100 * 1024; // 100KB
 pub const MAX_ENTRY_SIZE: usize = MAX_KEY_SIZE + MAX_VALUE_SIZE + MIN_ENTRY_SIZE;
 
 /// An entry in the Write-Ahead Log
@@ -39,9 +39,9 @@ pub const MAX_ENTRY_SIZE: usize = MAX_KEY_SIZE + MAX_VALUE_SIZE + MIN_ENTRY_SIZE
 ///
 /// ## Size Limits
 ///
-/// - Maximum key size: 1 MB
-/// - Maximum value size: 10 MB
-/// - Maximum entry size: ~11 MB
+/// - Maximum key size: 10 KB
+/// - Maximum value size: 100 KB
+/// - Maximum entry size: ~110 KB
 ///
 /// These limits prevent memory exhaustion and ensure reasonable performance.
 ///
@@ -491,7 +491,7 @@ mod tests {
     }
 
     // Edge cases and error conditions
-    /// Tests that Put entries enforce the 1MB key size limit.
+    /// Tests that Put entries enforce the 10KB key size limit.
     ///
     /// Verifies:
     /// - Keys larger than MAX_KEY_SIZE rejected
@@ -506,7 +506,7 @@ mod tests {
         assert!(matches!(result.unwrap_err(), Error::Corruption(_)));
     }
 
-    /// Tests that Put entries enforce the 10MB value size limit.
+    /// Tests that Put entries enforce the 100KB value size limit.
     ///
     /// Ensures:
     /// - Values larger than MAX_VALUE_SIZE rejected
@@ -521,7 +521,7 @@ mod tests {
         assert!(matches!(result.unwrap_err(), Error::Corruption(_)));
     }
 
-    /// Tests that Delete entries enforce the 1MB key size limit.
+    /// Tests that Delete entries enforce the 10KB key size limit.
     ///
     /// Verifies:
     /// - Delete operations have same key limits

--- a/ferrisdb-storage/tests/wal_integration_tests.rs
+++ b/ferrisdb-storage/tests/wal_integration_tests.rs
@@ -101,10 +101,10 @@ fn append_and_read_handle_entries_up_to_size_limits() {
 
     // Test with various sizes
     let test_sizes = vec![
-        (100, 1000),       // Small
-        (1024, 10240),     // Medium
-        (10240, 102400),   // Large
-        (102400, 1024000), // Very large (100KB key, 1MB value)
+        (100, 1000),     // Small
+        (1024, 10240),   // Medium
+        (10240, 102400), // Large
+        (8192, 81920),   // Large (8KB key, 80KB value)
     ];
 
     let writer = WALWriter::new(&wal_path, SyncMode::Normal, 100 * 1024 * 1024).unwrap();

--- a/ferrisdb-storage/tests/wal_property_tests.rs
+++ b/ferrisdb-storage/tests/wal_property_tests.rs
@@ -12,28 +12,17 @@ use tempfile::TempDir;
 
 // ==================== Strategies ====================
 
-// Generate valid keys (0 to 1MB)
+// Generate valid keys (0 to 10KB)
 prop_compose! {
-    fn valid_key()(size in 0usize..=1024*1024) -> Vec<u8> {
+    fn valid_key()(size in 0usize..=10*1024) -> Vec<u8> {
         vec![b'k'; size]
     }
 }
 
-// Generate valid values (0 to 10MB, but smaller in CI)
+// Generate valid values (0 to 100KB)
 prop_compose! {
-    fn valid_value()(size in 0usize..=max_value_size()) -> Vec<u8> {
+    fn valid_value()(size in 0usize..=100*1024) -> Vec<u8> {
         vec![b'v'; size]
-    }
-}
-
-// Adjust test data size based on environment
-fn max_value_size() -> usize {
-    if std::env::var("CI").is_ok() {
-        // Smaller values in CI for faster tests
-        1024 * 1024 // 1MB max in CI
-    } else {
-        // Full size for local development
-        10 * 1024 * 1024 // 10MB max locally
     }
 }
 
@@ -41,8 +30,8 @@ fn max_value_size() -> usize {
 prop_compose! {
     fn arbitrary_bytes()(size in 0usize..10000) -> Vec<u8> {
         let mut bytes = vec![0u8; size];
-        for i in 0..size {
-            bytes[i] = (i % 256) as u8;
+        for (i, byte) in bytes.iter_mut().enumerate().take(size) {
+            *byte = (i % 256) as u8;
         }
         bytes
     }
@@ -54,8 +43,8 @@ proptest! {
     /// Tests that Put entries preserve all data through encode/decode cycle.
     ///
     /// This property test verifies that:
-    /// - Arbitrary keys (0-1MB) are preserved exactly
-    /// - Arbitrary values (0-10MB) are preserved exactly
+    /// - Arbitrary keys (0-10KB) are preserved exactly
+    /// - Arbitrary values (0-100KB) are preserved exactly
     /// - Timestamps are preserved without modification
     /// - No data corruption occurs during serialization
     #[test]
@@ -142,16 +131,16 @@ proptest! {
         let _ = WALHeader::decode(&data);
     }
 
-    /// Tests that keys exceeding 1MB limit are always rejected.
+    /// Tests that keys exceeding 10KB limit are always rejected.
     ///
     /// Verifies:
-    /// - Enforcement of 1MB key size limit
+    /// - Enforcement of 10KB key size limit
     /// - Proper error type (Corruption) returned
     /// - Clear error messages about size limits
     /// - Protection against memory exhaustion
     #[test]
     fn oversized_keys_always_rejected(
-        size in (1024usize*1024 + 1)..=(2usize*1024*1024),
+        size in (10*1024usize + 1)..=(20*1024usize),
         value in valid_value(),
         timestamp in any::<u64>()
     ) {
@@ -166,17 +155,17 @@ proptest! {
         }
     }
 
-    /// Tests that values exceeding 10MB limit are always rejected.
+    /// Tests that values exceeding 100KB limit are always rejected.
     ///
     /// Ensures:
-    /// - Enforcement of 10MB value size limit
+    /// - Enforcement of 100KB value size limit
     /// - Consistent error handling across all oversized values
     /// - Protection against resource exhaustion
     /// - Clear error messages for debugging
     #[test]
     fn oversized_values_always_rejected(
         key in valid_key(),
-        size in (10usize*1024*1024 + 1)..=(20usize*1024*1024),
+        size in (100*1024usize + 1)..=(200*1024usize),
         timestamp in any::<u64>()
     ) {
         let oversized_value = vec![b'v'; size];


### PR DESCRIPTION
## Summary

This PR reduces the maximum allowed sizes for WAL entries to improve performance and memory usage:
- **Key limit**: 1MB → 10KB  
- **Value limit**: 10MB → 100KB

Closes #109

## Motivation

The previous limits (1MB keys, 10MB values) were excessive for typical use cases and caused:
- High memory usage during testing
- Slower property-based tests
- Unpredictable performance characteristics

## Changes

1. **Updated size constants** in `log_entry.rs`:
   - `MAX_KEY_SIZE`: 10KB
   - `MAX_VALUE_SIZE`: 100KB

2. **Updated all tests** to work with new limits:
   - Property test generators
   - Boundary tests
   - Size validation tests
   - Integration test data

3. **Removed CI optimization** in property tests since 100KB is fast enough for all environments

4. **Updated documentation** to reflect new limits

## Breaking Change

⚠️ **This is a breaking change**: Existing WAL files with entries exceeding the new limits will fail to read.

This is acceptable because:
- FerrisDB is in early development
- No production deployments exist
- The new limits are more reasonable for real-world usage

## Testing

- ✅ All WAL tests pass
- ✅ Property tests verify size enforcement
- ✅ Boundary tests confirm exact limits work
- ✅ Integration tests updated with appropriate data sizes

## Benefits

- ~100x reduction in maximum memory per entry
- Better CPU cache utilization  
- More predictable performance
- Faster test execution

🤖 Collaboration Notes:
The human requested reducing WAL size limits. We analyzed the codebase impact, implemented the changes systematically, and verified all tests pass. The CI-specific optimization was removed since tests now run quickly in all environments with the 100KB limit.

Co-Authored-By: Claude <noreply@anthropic.com>